### PR TITLE
feat!: Fail-Loud Doctrine — ADR-015, close Cluster A, release-ready 0.5.0 (epic #26)

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -36,3 +36,10 @@ jobs:
       run: |
         set -e
         poetry run pytest tests/
+
+    # Structural documentation checks (CIC references, cross-ADR integrity, unfilled
+    # placeholders). Complements tests/test_documentation_contracts.py, which asserts
+    # that documented claims match code. Neither ran in CI before 2026-08-02, which is
+    # how the README shipped a promise the package did not keep (register C-29).
+    - name: Validate documentation consistency
+      run: bash documentation/validate_docs.sh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,28 @@ The evaluation ontology has been updated to be more explicit and task-specific. 
 | `regression_uncertainty_metrics` | `regression_sample_metrics` |
 | `classification_uncertainty_metrics` | `classification_sample_metrics` |
 
-*Note: Legacy keys still work but will trigger a `DeprecationWarning`.*
+> **⚠️ Legacy keys were REMOVED in 0.4.0 — they no longer work.**
+>
+> Earlier documentation stated that legacy keys still worked and emitted a
+> `DeprecationWarning`. That was **incorrect**: the translation shim lived in
+> `EvaluationManager`, which was deleted before 0.4.0 was published. There is no
+> fallback and none will be restored.
+>
+> Since 0.5.0, an unrecognised config key **fails loudly** at
+> `NativeEvaluator.__init__` rather than being silently ignored:
+>
+> ```
+> ValueError: Unknown evaluation config key(s): ['targets'].
+> Valid keys: ['classification_point_metrics', ...]
+> ```
+>
+> Previously a legacy or misspelled metric key produced an **empty-but-successful
+> report** with no error at all. Migrate using the table above.
+>
+> This removal predates the deprecation policy now in force — see
+> [ADR-022](documentation/ADRs/022_evolution_and_stability.md), which requires a
+> `DeprecationWarning` in a published release plus one full release cycle before any
+> public symbol or config key is removed.
 
 ---
 
@@ -222,23 +243,28 @@ pip install views_evaluation
 The library follows a strict three-layer architecture (ADR-011):
 
 ```
-Level 0 — Pure Core (NumPy + SciPy only, zero framework imports)
-  EvaluationFrame       Canonical data container (y_true, y_pred, identifiers)
-  NativeEvaluator       Stateless evaluation engine (month/sequence/step schemas)
-  MetricCatalog         Genome registry mapping metrics → functions + required params
-  Profiles              Named hyperparameter sets (base, hydranet_ucdp, ...)
+Level 0 — Pure Core (NumPy + SciPy + sklearn; no dataframe libraries)
+  EvaluationFrame            Canonical data container (y_true, y_pred, identifiers)
+  NativeEvaluator            Stateless evaluation engine (month/sequence/step schemas)
+  MetricCatalog              Genome registry mapping metrics → functions + required params
+  native_metric_calculators  The metric kernels
+  Profiles                   Named hyperparameter sets (base, hydranet_ucdp, ...)
 
-Level 1 — Bridge / Adapter
-  EvaluationFrame       Validated NumPy data container
-  EvaluationReport      Results container with DataFrame/dict export
+Level 1 — Bridge / Emit
+  EvaluationReport      Results container with dict / DataFrame / MetricFrame export
+  MetricFrame           Typed, provenance-stamped evaluation-of-record (views-frames ADR-020)
 
-Level 2 — Legacy Orchestrator
-  MetricCatalog         Genome registry and parameter resolver
+Level 2 — Orchestration
+  External to this repository (e.g. views-pipeline-core)
 ```
+
+Each component appears in exactly one level; dependencies flow toward the core (ADR-011).
 
 **Key design decisions:**
 - **ADR-011**: No Pandas/Polars imports in Level 0 — math is framework-agnostic.
 - **ADR-013**: Fail-loud — all structural failures raise exceptions with actionable messages, never silently degrade.
+- **ADR-015**: Degenerate and empty results — a computation that cannot produce a result raises; it never returns a value standing in for one. A metric may return a number for a degenerate input only where that number is genuinely the answer (e.g. `MCR`'s `inf`), documented and tested.
+- **ADR-022**: Evolution and stability — public API removals require a `DeprecationWarning` in a prior published release plus one full release cycle.
 - **ADR-042**: Metric catalog — each metric declares its required hyperparameters ("genome"); values are resolved via Chain of Responsibility.  
 
 ---
@@ -252,20 +278,20 @@ views-evaluation/
 │   ├── adapters/
 │   │   └── __init__.py                     # Reserved for future framework bridges
 │   ├── evaluation/
-│   │   ├── config_schema.py               # EvaluationConfig TypedDict
+│   │   ├── config_schema.py               # EvaluationConfig TypedDict (authoritative key set)
 │   │   ├── evaluation_frame.py            # Core data container
-│   │   ├── evaluation_manager.py          # Legacy orchestrator (deprecated)
 │   │   ├── evaluation_report.py           # Results container
+│   │   ├── metric_frame.py                # Evaluation-of-record emit artifact (needs [frames])
 │   │   ├── metric_catalog.py              # ADR-042 registry + resolver
 │   │   ├── metrics.py                     # Typed metric dataclasses
 │   │   ├── native_evaluator.py            # Core evaluation engine
 │   │   └── native_metric_calculators.py   # Metric implementations
 │   └── profiles/
-│       ├── base.py                        # Standard hyperparameter defaults
+│       ├── base.py                        # Standard hyperparameter values
 │       └── hydranet_ucdp.py               # Domain-specific profile
-├── tests/                                 # 242 tests (Green/Beige/Red)
+├── tests/                                 # Green/Beige/Red suites (ADR-020)
 ├── documentation/
-│   ├── ADRs/                              # 17 Architecture Decision Records
+│   ├── ADRs/                              # Architecture Decision Records
 │   ├── CICs/                              # Class Intent Contracts
 │   ├── integration_guide.md               # Full API walkthrough
 │   └── evaluation_concepts.md             # Domain concepts

--- a/documentation/ADRs/015_degenerate_and_empty_results.md
+++ b/documentation/ADRs/015_degenerate_and_empty_results.md
@@ -90,7 +90,7 @@ Each path enumerated in the Context is ruled on individually below. These ruling
 
 ## Rationale
 
-**R1 — `MCR` keeps its sentinel.** `MCR = mean(y_pred) / mean(y_true)`. A zero-truth group is a property of conflict data, not a fault — most units are zero most of the time — so criterion 1 holds. `inf` (predicted conflict where none occurred) and `nan` (nothing predicted, nothing observed) are both interpretable calibration statements for that group. Documented at `native_metric_calculators.py:107-122` and asserted by two tests (`test_metric_catalog.py:329`, `:336`). All four criteria hold. **`Pearson` (R2) is the same case and is ruled the same way.**
+**R1 — `MCR` keeps its sentinel.** `MCR = mean(y_pred) / mean(y_true)`. A zero-truth group is a property of conflict data, not a fault — most units are zero most of the time — so criterion 1 holds. `inf` (predicted conflict where none occurred) and `nan` (nothing predicted, nothing observed) are both interpretable calibration statements for that group. Documented in `calculate_mcr_native`'s docstring (`native_metric_calculators.py`) and asserted by `tests/test_metric_catalog.py::TestMCR::test_zero_true_positive_pred_returns_inf` and `::test_zero_both_returns_nan`. All four criteria hold. **`Pearson` (R2) is the same case and is ruled the same way.**
 
 **R2 — `Pearson` keeps its `nan` sentinel.** ⚠ **This ruling was reversed on 2026-08-02, the same day it was made.** Both the original reasoning and the reversal are recorded here, because the mistake is instructive and should not be repeated.
 
@@ -151,7 +151,8 @@ Rejected on constitutional grounds, not preference. ADR-013 forbids downgrading 
 
 ## Implementation Notes
 
-- **Exception type:** `ValueError` throughout, consistent with existing config and metric failures (`metric_catalog.py:145-215`, `native_evaluator.py:49-76`).
+- **Exception type:** `ValueError` throughout, consistent with existing config and metric failures (`resolve_metric_params` in `metric_catalog.py`; `_validate_config`, `_resolve_task_and_metrics` and `_calculate_metrics` in `native_evaluator.py`).
+- **Cite symbols, not line numbers.** References in this ADR name functions, classes and test node IDs rather than line ranges, because line numbers drift the moment anything is inserted above them — including within the very commit that writes the citation.
 - **Message quality:** every raise must name **what was wrong**, **what was expected**, and **what the caller should change**. A message that only reports a symptom fails this ADR's intent.
 - **Level-0 logging exemption stands.** The Logging & Observability Standard §5.1 exempts Level-0 pure-math components from maintaining loggers; exceptions propagate to the orchestrator. Raises added under this ADR in Level-0 files must **not** introduce loggers. The Level-1 emit path (`MetricFrame`, `to_metric_frame`) does log at `ERROR` before raising.
 - **Detection belongs as early as the information exists.** Config failures raise at `NativeEvaluator.__init__`, not at `evaluate()`. Emit failures raise at `to_metric_frame()`, not inside `MetricFrame._validate` — the emit site holds the context needed for a useful message, and the container must remain able to represent anything `load()` reads back.

--- a/documentation/ADRs/015_degenerate_and_empty_results.md
+++ b/documentation/ADRs/015_degenerate_and_empty_results.md
@@ -1,0 +1,186 @@
+# ADR-015: Degenerate and Empty Results (The "No Empty Success" Rule)
+
+**Status:** Accepted  
+**Date:** 2026-08-02  
+**Deciders:** Project maintainers  
+**Consulted:** repo-assimilation (2026-08-02), review-rr strategic (2026-08-02)  
+**Informed:** All contributors, downstream consumers (views-pipeline-core, views-reporting)  
+
+---
+
+## Context
+
+ADR-013 established the Fail-Loud rule: structural failures must be raised explicitly and never silently degraded. It did not, however, say **what counts as a failure when there is nothing to compute**.
+
+That gap is not theoretical. A strategic review of the technical risk register on 2026-08-02 found that seven of fifteen open concerns shared a single root cause: with no doctrine for degenerate or empty results, each site improvised independently. The register groups them as **Causal Cluster A**, and it holds the register's only Tier-1 entry.
+
+The improvisations that resulted, all empirically verified on 2026-08-02:
+
+| Situation | Improvised behaviour |
+|---|---|
+| Misspelled metric-list config key | Returns `{'month100': {}, 'month101': {}}` — an empty report that looks successful |
+| Missing `steps` config key | Omits the entire step-wise schema |
+| `Ignorance`, observation above the top bin edge | `IndexError` on ordinary country-month data |
+| `Ignorance`, observation below the bottom edge | Negative-indexes into the **wrong bin**, returns a plausible number |
+| `Pearson`, constant input | Returns `nan` into the report, unflagged |
+| `to_metric_frame()` on an empty report | Emits a structurally valid **zero-row** evaluation-of-record |
+| `legacy_compatibility=True` | Returns `{}` for steps the caller explicitly requested |
+| `MCR`, zero-truth group | Returns `inf` or `nan` — **documented and tested** |
+
+The last row differs in kind from the others, and that difference is the substance of this ADR.
+
+The urgency is downstream. `EvaluationReport.to_metric_frame()` produces the **evaluation-of-record** consumed by views-reporting and views-pipeline-core. An empty-but-valid audit artifact is indistinguishable from a real one, so an upstream config typo becomes a clean-looking, permanently archived record of nothing.
+
+---
+
+## Decision
+
+> **A computation that cannot produce a result must raise. It must never return a value that represents the absence of a result.**
+
+A returned number is permitted **only when the number is itself the answer**, not when it stands in for one.
+
+### The test for a permitted exception
+
+A non-raising return is justified only if **all** of the following hold. Any exception must satisfy this test in writing, in this ADR.
+
+1. **The degenerate case is a property of the data, not a broken invariant.** This is the load-bearing criterion. Ask: *did something go wrong, or is the input simply like this?* A malformed config is a fault. A group where every unit is zero is a fact about conflict data. Faults raise; facts may be recorded.
+2. **The value is contracted** — documented in the function's docstring and in the relevant Intent Contract (ADR-021).
+3. **The value is tested** — a test asserts the sentinel for the degenerate input.
+4. **A consumer can distinguish it** from a computed ordinary result, or the distinction does not change any decision.
+
+Failing any of the four, the correct behaviour is to raise.
+
+> **Note on criterion 1 (revised 2026-08-02).** This criterion originally read *"the value
+> is mathematically defined for the input, not a placeholder chosen because no answer
+> exists."* That phrasing was wrong, and it produced a wrong ruling — see the reversal of
+> ruling 2 below. It invited the question *"is this number a real answer?"*, which sorts
+> cases by the **arithmetic** of the degenerate result rather than by **what caused it**.
+> That is the wrong axis. `MCR`'s `inf` and `Pearson`'s `nan` arise from the same kind of
+> event — data with no variation — and any test that separates them is sorting on an
+> irrelevance. What actually matters is whether the evaluator is looking at a fault it
+> should refuse to proceed past, or at data that is simply shaped that way.
+
+### What this rule forbids
+
+Restating the governing doctrine so it cannot be reinterpreted:
+
+- **No silent fixes** to keep a run moving.
+- **No repaired values.** Clamping an out-of-range input into range, substituting a neighbouring bin, or defaulting a missing parameter are all forbidden. *It is not the evaluator's job to fix values.*
+- **No magic numbers or strings** introduced to make a degenerate case tractable.
+- **No default values** standing in for absent configuration.
+- **No fallbacks.**
+- **No warnings in place of raising.** ADR-013 already forbids downgrading structural failures to warnings; the Logging & Observability Standard §9 lists it as a prohibited anti-pattern. This ADR does not reopen that.
+
+### Rulings
+
+Each path enumerated in the Context is ruled on individually below. These rulings are binding.
+
+| # | Path | Ruling | Basis |
+|---|---|---|---|
+| 1 | `MCR` on a zero-truth group | **Documented sentinel** — `inf` / `nan` retained | Passes all four criteria; see R1 |
+| 2 | `Pearson` on constant input | **Documented sentinel** — `nan` retained | ⚠ **Reversed 2026-08-02**; see R2 |
+| 3 | `MetricFrame.values` permitting `NaN` | **Permitted, unchanged** | See R3 |
+| 4 | Unknown / misspelled config key | **Raise at construction** | Direct application of the rule |
+| 5 | Missing `steps` config key | **Raise at construction** | Direct application of the rule |
+| 6 | Zero-row `to_metric_frame()` emit | **Raise at emit** | Direct application of the rule |
+| 7 | `legacy_compatibility` truncating requested steps | **Raise** | See R7 |
+| 8 | `Ignorance` observation outside the bin range | **Raise**, both tails | See R8 |
+
+---
+
+## Rationale
+
+**R1 — `MCR` keeps its sentinel.** `MCR = mean(y_pred) / mean(y_true)`. A zero-truth group is a property of conflict data, not a fault — most units are zero most of the time — so criterion 1 holds. `inf` (predicted conflict where none occurred) and `nan` (nothing predicted, nothing observed) are both interpretable calibration statements for that group. Documented at `native_metric_calculators.py:107-122` and asserted by two tests (`test_metric_catalog.py:329`, `:336`). All four criteria hold. **`Pearson` (R2) is the same case and is ruled the same way.**
+
+**R2 — `Pearson` keeps its `nan` sentinel.** ⚠ **This ruling was reversed on 2026-08-02, the same day it was made.** Both the original reasoning and the reversal are recorded here, because the mistake is instructive and should not be repeated.
+
+*Original ruling (wrong):* Pearson raises. Correlation requires variance in both series; on constant input it is *undefined*, so `nan` denotes the **absence** of a result rather than a result. Under criterion 1 as first written — "is the value mathematically defined?" — that failed, while `MCR`'s `inf` passed. The asymmetry was stated as: MCR's `inf` is an answer, Pearson's `nan` is a shrug.
+
+*Why it was wrong:* the criterion was sorting on the wrong axis. It asked what the degenerate *number* is, when what matters is what **caused** it. Both cases arise from the same event — data with no variation. Splitting them apart put two identical situations in different categories on the strength of an arithmetic coincidence.
+
+*What made the error concrete:* a "predict zero everywhere" baseline has a constant prediction series. ADR-041 states that reports exist to compare *"ensemble models against constituent models and baselines"*, so evaluating such a model is routine, not exotic. Under the original ruling, evaluating any constant baseline with `Pearson` in the metric list **aborted the entire run** — every metric, every schema — because one metric was undefined on one group. Verified 2026-08-02.
+
+That blast radius is the real signal. Fail-loud exists to stop the evaluator proceeding past a **fault**. A baseline model is not a fault; a constant prediction series is a *finding about the model*, and an all-zero month is a *fact about conflict data*, where most units are zero most of the time. Halting an entire evaluation over it is disproportionate and makes a standard workflow impossible.
+
+*Corrected ruling:* `Pearson` returns `nan` for a constant series, documented in `MCR`'s style and tested. Consumers treat it as "not computable for this group"; `to_metric_frame()`'s `nanmean` already excludes it from aggregates. The `ConstantInputWarning` is suppressed at the call site — with the case contracted and handled, the warning is noise.
+
+This leaves `MCR` and `Pearson` in the **same** category for the **same** stated reason, which is the coherent outcome. Criterion 1 was rewritten accordingly (see the note under The test above).
+
+**R3 — `MetricFrame` keeps permitting `NaN`.** This is a container invariant, not a computation. `MetricFrame.load()` must faithfully reconstruct whatever `save()` wrote, including historical frames; and the cross-group aggregate row deliberately carries `nanmean` semantics. Forbidding `NaN` in the container would break the round-trip and change a published cross-repo envelope that views-reporting already consumes, without preventing a single silent failure — because the failures are prevented at the *emit* site (ruling 6) where the context to diagnose them exists. Criterion 4 governs: the distinction is preserved upstream, so the container need not police it.
+
+**R7 — Truncation of *requested* steps raises.** `legacy_compatibility=True` exists to reproduce historic zip-truncation for parity, which is a legitimate opt-in. The defect is not truncation; it is that truncated steps are returned as **empty dicts** rather than omitted. Verified 2026-08-02: with `config['steps'] = [1,2,3,4,5]` and a shortest origin of 3, the report contains `step04: {}` and `step05: {}`. Those keys were **explicitly requested by the caller** and come back looking evaluated while emitting no MetricFrame rows — the same pattern that makes ruling 4 a Tier-1 concern.
+
+The caller's `config['steps']` is a request list, not a hint. Silently not fulfilling it is a contract violation regardless of which flag was set. If truncation is wanted, the caller must not request the steps it does not want scored.
+
+**R8 — `Ignorance` raises on out-of-range observations.** An observation outside the configured bins means the profile's `bins` do not fit the target. Two alternatives were considered and rejected under the doctrine: **clamping** into the edge bins is a silent fix that redefines the metric precisely at the tails, where conflict data matters most; **widening the base profile's ceiling** is a magic number that relocates the cliff without removing it and does nothing for the underflow. The configuration is wrong and must be corrected by the researcher.
+
+---
+
+## Considered Alternatives
+
+### Alternative A: No exceptions — every degenerate case raises
+
+Rejected. It would break `MCR`'s documented, tested contract and force the cross-repo `MetricFrame` envelope to change, for no gain in silence-prevention. The four-criteria test achieves the same guarantee while preserving genuinely defined answers.
+
+### Alternative B: Keep all existing sentinels, document them
+
+Rejected. It preserves `Pearson`'s `nan` — a value denoting no-answer — flowing unflagged into reports for degenerate groups. That is the failure mode C-22 identifies, and documenting a shrug does not make it an answer.
+
+### Alternative C: Warn instead of raise
+
+Rejected on constitutional grounds, not preference. ADR-013 forbids downgrading structural failures to warnings, and the Logging & Observability Standard §9 lists it as a prohibited anti-pattern.
+
+---
+
+## Consequences
+
+### Positive
+
+- Cluster A's root cause is removed; ten register concerns become closable.
+- A misconfigured evaluation cannot masquerade as a successful one, in the report or in the archived evaluation-of-record.
+- Future contributors have a written test for permissible exceptions instead of a precedent to imitate.
+- Degenerate-group failures name the group, so they are diagnosable rather than mysterious.
+
+### Negative
+
+- **Breaking behaviour changes in a published library.** Configs that returned an empty-but-successful report will raise (rulings 4, 5); `legacy_compatibility` callers requesting steps beyond the shortest sequence will raise (ruling 7); `Ignorance` raises on observations outside its bins (ruling 8). Downstream consumers must be told before 0.5.0 ships — governed by ADR-022's deprecation policy. (Ruling 2 was *reversed* precisely because its breaking change — aborting any evaluation of a constant baseline — was disproportionate to the fault it was catching.)
+- Some evaluations that previously "worked" will now stop. That is intended, but it transfers cost to callers with degenerate data, who must fix their configuration or their profile.
+- The four-criteria test requires judgement. It is deliberately narrow, but it is not mechanical.
+
+---
+
+## Implementation Notes
+
+- **Exception type:** `ValueError` throughout, consistent with existing config and metric failures (`metric_catalog.py:145-215`, `native_evaluator.py:49-76`).
+- **Message quality:** every raise must name **what was wrong**, **what was expected**, and **what the caller should change**. A message that only reports a symptom fails this ADR's intent.
+- **Level-0 logging exemption stands.** The Logging & Observability Standard §5.1 exempts Level-0 pure-math components from maintaining loggers; exceptions propagate to the orchestrator. Raises added under this ADR in Level-0 files must **not** introduce loggers. The Level-1 emit path (`MetricFrame`, `to_metric_frame`) does log at `ERROR` before raising.
+- **Detection belongs as early as the information exists.** Config failures raise at `NativeEvaluator.__init__`, not at `evaluate()`. Emit failures raise at `to_metric_frame()`, not inside `MetricFrame._validate` — the emit site holds the context needed for a useful message, and the container must remain able to represent anything `load()` reads back.
+
+---
+
+## Validation & Monitoring
+
+- Every ruling that changes behaviour carries a **Red** test per ADR-020.
+- The suite must finish with **zero warnings**. A `ConstantInputWarning` reaching the runner means a degenerate case is being *encountered* rather than *contracted*; under ruling 2 it is suppressed at the call site precisely because it is handled.
+- **Before ruling that a degenerate case must raise, identify the blast radius.** Rulings here apply per-metric per-group, but a raise propagates to the whole `evaluate()` call — every metric, every schema. Ruling 2 was reversed on exactly this point. Ask what legitimate workflow the raise makes impossible, and check it against a real one (for ruling 2, it was baseline comparison per ADR-041).
+- Intent Contracts (ADR-021) must record each new failure mode; a documentation-contract test enforces that they stay in step.
+- Sentinels permitted under this ADR must retain their asserting tests. Deleting such a test is a violation of criterion 3, not a test-cleanup decision.
+
+---
+
+## Open Questions
+
+- **The positional-`step` contract.** `step` is assumed to mean 1-indexed positional lead time and is enforced nowhere; the adapter that synthesised it was removed in Phase 3. This is a cross-repo contract question, deliberately **not** settled here. Tracked as register C-20's remaining half.
+- **Profile-domain validation.** Ruling 8 raises when an observation falls outside a profile's bins, but nothing validates at *registration* that a profile's bins suit its intended target. A profile-level domain declaration would move the failure earlier still. Out of scope here.
+
+---
+
+## References
+
+- ADR-013 (Observability and Explicit Failure) — the parent rule this ADR completes
+- ADR-014 (Boundary Contracts and Validation) — where validation belongs
+- ADR-020 (Multi-Perspective Testing) — Red/Beige/Green obligations
+- ADR-021 (Intent Contracts for Classes) — where failure semantics are recorded
+- ADR-022 (Evolution and Stability) — governs announcing the breaking changes above
+- `documentation/standards/logging_and_observability_standard.md` §3, §5.1, §9
+- `reports/technical_risk_register.md` — Causal Cluster A; C-02, C-20, C-22, C-27, C-28, C-30

--- a/documentation/ADRs/022_evolution_and_stability.md
+++ b/documentation/ADRs/022_evolution_and_stability.md
@@ -1,10 +1,10 @@
 # ADR-022: Rules for Evolution and Stability
 
-**Status:** Proposed (Deferred)  
-**Date:** 2026-02-25  
-**Deciders:** —  
-**Consulted:** —  
-**Informed:** All contributors  
+**Status:** Accepted  
+**Date:** 2026-02-25 (deferred) · **Activated:** 2026-08-02  
+**Deciders:** Project maintainers  
+**Consulted:** 2026-04-03 incident investigation; review-rr strategic (2026-08-02)  
+**Informed:** All contributors, downstream consumers (views-pipeline-core, views-reporting)  
 
 ---
 
@@ -12,24 +12,113 @@
 
 The preceding ADRs establish the ontology, topology, and semantic authority at a point in time. What they do not yet define is how the system is allowed to change over time (versioning, breaking changes, backward compatibility).
 
+### Why this ADR was activated (2026-08-02)
+
+This ADR was deliberately deferred in 2026-02 and listed its own reconsideration triggers. **The second trigger fired.**
+
+On **2026-04-03**, `EvaluationManager` and `PandasAdapter` were deleted in a single PR (#16) with no deprecation warning in any prior release. **All six downstream integration tests in views-pipeline-core crashed with `ModuleNotFoundError`.** The Phase 4 bridge wrapper that would have softened the removal was deleted in the same commit that merged the purge. Tracked as risk register **C-13** (Tier 2).
+
+Two further facts made deferral untenable:
+
+1. **The breakage reached users.** Published `v0.4.0` (2026-05-18) ships without `EvaluationManager`, `PandasAdapter`, and the legacy-config-key shim — while its README still tells users legacy keys work and emit a `DeprecationWarning`. Users are currently reading a promise the package does not keep.
+2. **ADR-015 adds more breaking changes.** Rulings 2, 4, 5 and 7 turn previously-silent successes into raises. Shipping those without a policy would repeat 2026-04-03 deliberately.
+
+C-13's register entry states the reason a policy, not a register entry, is the fix: *as a register entry it has no enforcement point and will re-fire on every release.*
+
 ## Decision
 
-No decision is made at this time. Rules governing stability, evolution, and backward compatibility are **explicitly deferred**.
+The deferral is **withdrawn**. The following rules govern evolution of this repository.
 
-This ADR exists to reserve a place for a future decision and prevent ad-hoc policies from emerging unnoticed.
+### 1. What constitutes public API
 
-## Trigger Conditions for Reconsideration
+The public API is **every symbol exported in `views_evaluation/__init__.py:__all__`**, plus the documented behaviour of those symbols: constructor signatures, method signatures, return types, raised exception types, and the config keys declared in `EvaluationConfig`.
 
-This ADR should be revisited when:
-- Reproducibility across time becomes a contractual requirement.
-- Breaking changes begin to incur high coordination costs.
-- Contributors express uncertainty about what is safe to change.
+The `MetricFrame` on-disk format and axis vocabulary are additionally a **cross-repo contract** and are treated as public API regardless of `__all__`.
+
+Anything else — module paths, private helpers, internal dict shapes — is not public and may change without notice.
+
+### 2. Deprecation contract
+
+Before an `__all__`-exported symbol is **removed**:
+
+1. A `DeprecationWarning` must ship in a **published release**, naming the replacement.
+2. **At least one full release cycle** must pass between the deprecating release and the removing release.
+3. The deprecation must be recorded in the release notes of both releases.
+
+The same applies to removing a supported config key, narrowing an accepted input, or changing a raised exception type.
+
+### 3. Behaviour changes that make previously-accepted input fail
+
+ADR-015 introduces raises where the library previously returned a value. These are **not** symbol removals, so rule 2's warning-first mechanism does not apply — there is no symbol to warn on, and emitting a warning instead of raising is forbidden by ADR-013 and ADR-015.
+
+Such changes are governed instead by:
+
+1. They must be **announced in release notes** as breaking, with the specific inputs that now fail.
+2. Downstream consumers known to be affected must be **notified before** the release is cut, not after.
+3. The release notes must state the migration: what the caller changes to keep working.
+
+### 4. `DeprecationWarning` versus fail-loud — the boundary
+
+These two rules can appear to conflict. They do not, and the distinction is this:
+
+| Situation | Correct response | Governed by |
+|---|---|---|
+| A **structural failure** — invalid config, undefined computation, broken invariant | **Raise.** Never warn | ADR-013, ADR-015 |
+| A **still-supported but scheduled-for-removal** API that works correctly today | **`DeprecationWarning`**, then remove a cycle later | This ADR, rule 2 |
+
+A `DeprecationWarning` announces a *future* removal of something that currently works. It is never a substitute for raising on something that is already wrong. Where a deprecated path would also produce an incorrect result, ADR-013 wins: raise.
+
+### 5. Versioning
+
+The project follows Semantic Versioning, with the standard `0.x` caveat made explicit:
+
+- **While `0.x`:** the public API carries no stability guarantee. Breaking changes may ship in a MINOR bump — but rules 2 and 3 still apply in full. Deferred stability is not deferred *communication*.
+- **From `1.0.0`:** breaking changes require a MAJOR bump.
+- A release that removes a symbol or breaks behaviour **must** bump at least MINOR; it may never ship as PATCH.
+
+`1.0.0` should be cut when downstream consumers require a stability guarantee — not before.
+
+### 6. Retroactive position on the 0.4.0 removals
+
+The `EvaluationManager` / `PandasAdapter` / legacy-key removals shipped in 0.4.0 without notice. That cannot be undone, and the shim will **not** be restored: it has been absent from the released package since 2026-05-18, and after ADR-015 ruling 4 a legacy key fails loudly rather than silently, which is the better outcome.
+
+What is owed instead:
+
+- The README migration notice must be corrected to describe what the package actually does. *(This is the fix for C-29.)*
+- The 0.5.0 release notes must retrospectively record the 0.4.0 removals as breaking.
+
+### 7. Enforcement
+
+This policy is checked at two points:
+
+- **Release checklist** (below) — worked through before any `poetry publish`.
+- **CI** — `tests/test_documentation_contracts.py` asserts that documentation makes no support claim the code does not honour, which is the specific failure that produced C-29.
+
+#### Release checklist
+
+- [ ] Does this release remove any `__all__` symbol or supported config key? If so, did a `DeprecationWarning` ship at least one release ago?
+- [ ] Does this release make previously-accepted input fail? If so, are the release notes explicit, and have known consumers been notified?
+- [ ] Does the version bump match the change class (rule 5)?
+- [ ] Do the release notes list every breaking change with its migration?
+- [ ] Does `MetricFrame`'s format or axis vocabulary change? If so, has it been agreed with views-reporting and views-pipeline-core?
 
 ## Consequences
 
 ### Positive
-- Avoids premature or brittle guarantees.
-- Preserves flexibility during early evolution.
+- Downstream consumers get advance signal instead of `ModuleNotFoundError` in CI.
+- The policy has a named enforcement point, so it stops depending on whoever happens to remember.
+- The fail-loud / deprecate boundary is written down, so ADR-013 and this ADR cannot be read as contradicting.
+- `0.x` flexibility is preserved without using it as an excuse for silent breakage.
 
 ### Negative
-- Some uncertainty remains about long-term guarantees.
+- A removal now takes at least two release cycles, which slows cleanup.
+- Requires release-notes discipline that this repository has not previously practised.
+- Rule 3 depends on knowing who the consumers are; that knowledge is currently informal.
+
+## References
+
+- ADR-013 (Observability and Explicit Failure) — why warnings never replace raising
+- ADR-015 (Degenerate and Empty Results) — the breaking changes rule 3 governs
+- `reports/technical_risk_register.md` — C-13 (this policy's origin), C-29 (the documentation half)
+- 2026-04-03 incident investigation — 6/6 downstream integration tests crashed
+- `views_evaluation/__init__.py:14-34` — the `__all__` surface this policy governs

--- a/documentation/ADRs/031_evaluation_metrics.md
+++ b/documentation/ADRs/031_evaluation_metrics.md
@@ -10,8 +10,19 @@
 In the context of the VIEWS pipeline, it is necessary to evaluate the models using a robust set of metrics that account for the characteristics of conflict data, such as right-skewness and zero-inflation in the outcome variable.
 
 ## Decision
-> **Note:** As of Jan 2026, several metrics are defined in the ADR but not yet implemented in the code.
-> - **Not Implemented:** `Sinkhorn Distance (SD)`, `Variogram`, `Brier Score`, `Jeffreys Divergence`.
+> **Implementation status (verified 2026-08-02).** `METRIC_CATALOG` in
+> `views_evaluation/evaluation/metric_catalog.py` is the authoritative source — each
+> `MetricSpec` carries an `implemented` flag, and an unimplemented metric raises if
+> requested.
+> - **Not implemented:** `SD` (Sinkhorn Distance), `Variogram`, `pEMDiv`, `Jeffreys`.
+> - **Brier Score IS implemented** as of 2026-04-09, split into three task-explicit
+>   variants: `Brier_cls_point`, `Brier_cls_sample`, `Brier_rgs_sample`. The `_cls_`/
+>   `_rgs_` infix denotes classification vs. regression context. `Brier_rgs_point` is
+>   deliberately absent — a regression point estimate is not a probability.
+>
+> _(This note previously listed Brier Score as unimplemented and omitted `pEMDiv`
+> entirely — wrong in both directions, and stale for four months. Corrected 2026-08-02;
+> the detection gap that allowed it is register **C-34**.)_
 
 Below are the evaluation metrics used to assess the performance of models in the VIEWS pipeline:
 

--- a/documentation/ADRs/040_evaluation_input_schema.md
+++ b/documentation/ADRs/040_evaluation_input_schema.md
@@ -14,9 +14,20 @@ The native path via `EvaluationFrame` is the sole integration path. The legacy
 
 ## Decision
 
-### Pandas Input Format (both paths)
+### Caller-side Pandas convention (NOT this library's input format)
 
-Both integration paths accept:
+> **⚠ Scope (clarified 2026-08-02).** `views-evaluation` does **not** accept DataFrames.
+> Its sole input is an `EvaluationFrame` of NumPy arrays. The Pandas layout below is the
+> **upstream convention observed by callers** (views-pipeline-core and model repos) that
+> the identifier synthesis in the next section is derived from — it documents where
+> `time`/`unit`/`origin`/`step` come from, not an interface this library exposes.
+>
+> The `PandasAdapter` that once consumed this format was deleted in Phase 3 along with
+> `EvaluationManager`; conversion is now entirely the caller's responsibility. This
+> section previously read "Pandas Input Format (both paths)", which implied a
+> DataFrame-accepting path that has not existed since 2026-04-01 (register **C-34**).
+
+Callers producing an `EvaluationFrame` typically start from:
 
 1. **Actuals**: A single `DataFrame` of observed values.
    - Index: `MultiIndex` of `(month_id, entity_id)`

--- a/documentation/ADRs/041_evaluation_output_schema.md
+++ b/documentation/ADRs/041_evaluation_output_schema.md
@@ -1,23 +1,61 @@
 # ADR-041: Evaluation Output Schema
 
-**Status:** Proposed  
-**Date:** 2025-06-16  
-**Deciders:** Xiaolong  
-**Consulted:** —  
-**Informed:** All contributors  
+**Status:** Accepted  
+**Date:** 2025-06-16 · **Revised:** 2026-08-02  
+**Deciders:** Xiaolong; revised by project maintainers  
+**Consulted:** views-frames ADR-020 (MetricFrame contract home)  
+**Informed:** All contributors, views-pipeline-core, views-reporting  
 
 ## Context
-Standardized reports are necessary for comparing ensemble models against constituent models and baselines.
+
+Standardized outputs are necessary for comparing ensemble models against constituent models and baselines.
+
+The 2025 version of this ADR asserted that *"views-evaluation returns a structured dictionary, and views-pipeline-core handles the persistence to disk"*, and listed JSON and HTML report formats. **Both claims became false and stayed false for months.** `EvaluationReport.to_metric_frame()` and `MetricFrame.save()` shipped in PR #22, and `save()` writes three files to disk directly. No HTML has ever been produced by this library. The ADR was also left at `Proposed`, so the output surface consumers actually build against was governed by nothing. Corrected here; the detection gap is register **C-34**.
 
 ## Decision
-We define a standard output schema for evaluation reports. To prevent circular dependencies, `views-evaluation` returns a structured dictionary, and `views-pipeline-core` handles the persistence to disk.
 
-### Formats
-1. **JSON**: Machine-readable structured data.
-2. **HTML**: Human-readable report with visualizations.
+`views-evaluation` produces **three output forms**, and it **does** write to disk for one of them.
 
-### Schema Overview (JSON)
-The JSON structure includes metadata (Target, Level, Partition, Training/Testing periods) and an `Evaluation Results` list containing metric values for each model evaluated.
+### 1. In-memory result structure (the mathematical output)
+
+`EvaluationReport` holds `{schema: {group_id: {metric: value}}}` for the three schemas of ADR-032. Exposed via:
+
+- `to_dict()` — nested plain dict; the pandas-free, extra-free path.
+- `get_schema_results(schema)` — mapped onto the typed metrics dataclasses.
+- `to_dataframe(schema)` — pandas DataFrame; requires the optional `dataframe` extra.
+
+`views-evaluation` does **not** serialise these to JSON or render HTML. That remains the orchestrator's job, and the original rationale still holds for them: formatting and run context belong where the run is orchestrated.
+
+### 2. The evaluation-of-record (`MetricFrame`) — persisted by this library
+
+`EvaluationReport.to_metric_frame()` emits a typed, provenance-stamped `MetricFrame`: a `float32` value column plus the six string axes `(eval_type, target, metric, group_id, partition, level)`, with one row per `(group, metric)` and a cross-group aggregate row keyed `group_id="mean"`.
+
+**`MetricFrame.save(directory)` writes `values.npy`, `identifiers.npz` and `metadata.json`.** This library therefore *does* persist — narrowly, in its own format, for the audit record only. This does not reintroduce a circular dependency: the format is self-contained and `views-pipeline-core` chooses the location.
+
+**The contract's home is views-frames ADR-020**, which owns the `FrameMetadata` provenance vocabulary and the `assert_frame_envelope` conformance checker this artifact satisfies. This ADR is the local record of what views-evaluation emits and does not restate that contract.
+
+### 3. Failure output
+
+There is none by design. A computation that cannot produce a result raises (**ADR-015**); a vacuous emit raises rather than persisting an empty record. There is no partial-output or error-report format.
+
+## Consequences
+
+### Positive
+- The output surface consumers build against is now governed by an Accepted ADR rather than a Proposed one.
+- The disk-writing boundary is stated explicitly instead of being denied.
+
+### Negative
+- Two output paths (`to_dict` for orchestrators, `MetricFrame` for the audit record) must be kept semantically consistent; nothing enforces that they agree.
+- The authoritative contract lives in another repo, so a reader must follow a cross-repo link. Tracked as part of **C-24**.
 
 ## Rationale
-Saving reports within `views-pipeline-core` ensures full control over formatting and context while keeping `views-evaluation` focused on the mathematical core.
+
+Splitting "results the orchestrator formats" from "the record that must survive for audit" is why this library persists one and not the other. Report rendering has many valid presentations and belongs with the orchestrator; the evaluation-of-record has exactly one correct form and must be reproducible byte-for-byte, which argues for the producer owning its serialisation.
+
+## References
+
+- views-frames **ADR-020** — MetricFrame contract home, `FrameMetadata`, `assert_frame_envelope`
+- **ADR-015** — why there is no partial or error output
+- **ADR-032** — the three schemas whose results this carries
+- `documentation/CICs/EvaluationReport.md`, `documentation/CICs/MetricFrame.md`
+- Register **C-24** (contract drift), **C-26** (float32 / `schema_version`), **C-34** (the drift that produced this revision)

--- a/documentation/ADRs/README.md
+++ b/documentation/ADRs/README.md
@@ -18,6 +18,7 @@ We follow a hierarchical numbering scheme to organize decisions from the most fo
 - **012**: [Authority over Inference](012_authority_over_inference.md)
 - **013**: [Observability and Explicit Failure](013_observability_and_explicit_failure.md)
 - **014**: [Boundary Contracts and Validation](014_boundary_contracts_and_validation.md)
+- **015**: [Degenerate and Empty Results](015_degenerate_and_empty_results.md)
 
 ### 02x: Engineering Discipline & Quality
 *Standards for implementation and verification.*
@@ -36,6 +37,7 @@ We follow a hierarchical numbering scheme to organize decisions from the most fo
 *Schemas for I/O and external systems.*
 - **040**: [Evaluation Input Schema](040_evaluation_input_schema.md)
 - **041**: [Evaluation Output Schema](041_evaluation_output_schema.md)
+- **042**: [Metric Catalog](042_metric_catalog.md)
 
 ---
 
@@ -46,9 +48,10 @@ We follow a hierarchical numbering scheme to organize decisions from the most fo
 - **Authority (012)** defines who owns meaning.
 - **Observability (013)** enforces failure semantics.
 - **Boundary Contracts (014)** define interaction rules.
+- **Degenerate Results (015)** defines what counts as a failure when there is nothing to compute.
 - **Testing (020)** verifies system integrity.
 - **Intent Contracts (021)** bind class-level behavior.
-- **Evolution (022)** (deferred) — rules for stability.
+- **Evolution (022)** governs deprecation, breaking changes, and versioning.
 - **Risk Register (023)** tracks structural concerns.
 - **Silicon Agent Protocol (001)** constrains automated modification.
 

--- a/documentation/CICs/EvaluationFrame.md
+++ b/documentation/CICs/EvaluationFrame.md
@@ -2,7 +2,7 @@
 
 **Status:** Active  
 **Owner:** Evaluation Core  
-**Last reviewed:** 2026-04-02  
+**Last reviewed:** 2026-08-02  
 **Related ADRs:** ADR-010 (Ontology), ADR-011 (Topology), ADR-012 (Authority)
 
 ---
@@ -53,6 +53,13 @@ The canonical, framework-agnostic internal representation of a forecasting evalu
 - Raises `ValueError` if required identifiers (`time`, `unit`, `origin`, `step`) are absent.
 - Raises `ValueError` if any identifier array contains `NaN` or `None` (as per ADR-012).
 - Raises `ValueError` if `y_true` or `y_pred` contain `NaN` or infinity (as per ADR-013).
+- Raises `ValueError` if `y_true` or `y_pred` is object-dtype (Pure NumPy contract, ADR-011).
+- Raises `ValueError` if **`y_true` is not 1-D** `(N,)`. Added 2026-08-02 (C-31) as the symmetric partner of the `y_pred` check below; an un-squeezed `(N, 1)` column previously constructed successfully, reported a plausible `n_rows`, and failed much later inside `_guard_shapes` as a *metric* error rather than an input-contract one.
+- Raises `ValueError` if `y_pred` is not 2-D `(N, S)` (C-03).
+
+Shape is validated **after** dtype, so a non-numeric array is reported as a dtype problem rather than a shape one.
+
+**Loudness note:** this class is Level 0 and maintains **no logger** — exceptions propagate to the orchestrator (logging standard §5.1).
 
 ---
 
@@ -114,7 +121,7 @@ sub_ef = ef.select_indices(month_groups[100])
 
 ## 12. Known Deviations
 
-- **Rectangular sample invariant not enforced:** Direct construction does not validate that all rows of `y_pred` have the same number of samples. Only well-designed external adapters guard against ragged arrays. A directly-constructed frame with ragged `y_pred` would cause indexing errors deep in metric calculations. (Risk register C-03)
+- ~~**Rectangular sample invariant not enforced**~~ — **resolved.** `_validate` now rejects any `y_pred` that is not 2-D, so a ragged array (which NumPy materialises as object-dtype) cannot be constructed: it is caught by either the object-dtype gate or the ndim gate. (Risk register C-03, closed 2026-03-31; deviation cleared here 2026-08-02.)
 - **Integer identifier NaN not checked:** Validation checks float and object identifiers for NaN/None, but integer-typed identifiers are not checked (NumPy integers cannot represent NaN, so this is safe in practice but not explicitly documented).
 - **No immutability enforcement:** The contract claims "State Immutability" via new-instance methods, but `y_true`, `y_pred`, and `identifiers` are publicly mutable attributes. Nothing prevents `ef.y_true[0] = 999` after construction.
 

--- a/documentation/CICs/EvaluationReport.md
+++ b/documentation/CICs/EvaluationReport.md
@@ -2,7 +2,7 @@
 
 **Status:** Active  
 **Owner:** Evaluation Core  
-**Last reviewed:** 2026-06-25  
+**Last reviewed:** 2026-08-02  
 **Related ADRs:** ADR-010 (Ontology), ADR-041 (Output Schema), views-frames ADR-020 (MetricFrame contract home)
 
 ---
@@ -57,6 +57,9 @@ A structured, framework-agnostic container for evaluation results. It decouples 
 - Raises `ValueError` if a computed metric name has no corresponding field in the typed metrics dataclass (FM1 guard against silent metric loss).
 - Fails loud if the input result structure is inconsistent.
 - `to_metric_frame()` raises `ImportError` (loud, actionable) if the optional `views-frames` dependency is not installed.
+- `to_metric_frame()` raises `ValueError` if the report contains **no metric values for any schema** (ADR-015 ruling 6, risk register C-30). Such an emit previously produced a structurally valid **zero-row** MetricFrame that satisfied `assert_frame_envelope` and persisted to disk as a legitimate-looking audit artifact recording nothing. The message names the target and which schemas were present-but-empty. A **partial** report — at least one metric value in any schema — still emits normally.
+
+**Loudness note:** this class is Level 0 and maintains no logger, with **one deliberate exception**: the `to_metric_frame()` emit path logs at `ERROR` before raising, because it belongs to Level 1 (it produces the persisted, cross-repo evaluation-of-record). Logging follows the emit path, not the file (logging standard §5.1). No other raise in this class logs.
 
 ---
 

--- a/documentation/CICs/MetricCatalog.md
+++ b/documentation/CICs/MetricCatalog.md
@@ -2,7 +2,7 @@
 
 **Status:** Active  
 **Owner:** Evaluation Core  
-**Last reviewed:** 2026-04-04  
+**Last reviewed:** 2026-08-02  
 **Related ADRs:** ADR-042 (Metric Catalog), ADR-012 (Authority), ADR-013 (Observability)
 
 ---
@@ -42,6 +42,21 @@ A genome registry and Chain of Responsibility resolver for evaluation metric hyp
   - `profile` is a named evaluation profile dict (e.g. `BASE_PROFILE`).
 - **Metric functions:** Each function referenced by a `MetricSpec` must accept `(y_true, y_pred, **resolved_params)`.
 - **Genome completeness:** All hyperparameters required by a metric function must be declared in the spec's `genome` tuple.
+- **Genome honesty (converse):** Every parameter declared in a `genome` must actually be *consumed* by its function, **or be an explicitly documented reserved placeholder**. A declared-but-inert parameter that is *not* documented as such is a contract violation — it presents as a tuning knob that changes nothing, and will mislead the next person who tries to use it. Added 2026-08-02 (C-28b).
+
+  **Currently one documented exception exists:**
+
+  | Metric | Inert params | Status |
+  |---|---|---|
+  | `Ignorance` | `low_bin`, `high_bin` | **Reserved placeholders.** `np.histogram_bin_edges` ignores `range=` whenever `bins` is a sequence, which it always is in shipped profiles. Retained deliberately for planned work, **not** because they function. |
+
+  A reserved placeholder must carry **all** of:
+  1. A status block in the metric function's docstring stating plainly that it has no effect, why, and what it must conform to if activated.
+  2. Warnings at every site that supplies it — the `MetricSpec` and every profile entry — so nobody encounters the value without the caveat.
+  3. Tests pinning the *current* inert status, so activation or deletion both break a test and force the decision to be recorded rather than drift in silently (`tests/test_metric_catalog.py::TestIgnoranceReservedPlaceholders`).
+  4. An open risk-register entry (C-28) carrying the use-it-or-lose-it decision.
+
+  **A placeholder that loses any of those four stops being a placeholder and becomes dead configuration — delete it.**
 
 ---
 
@@ -64,6 +79,22 @@ A genome registry and Chain of Responsibility resolver for evaluation metric hyp
 - `ValueError` if `lower_quantile >= upper_quantile` for metrics requiring both (e.g. QIS).
 
 All failures are immediate and explicit. No warnings, no fallbacks, no silent degradation.
+
+### Degenerate-input semantics of dispatched metrics (ADR-015)
+
+The catalog dispatches to metric kernels whose degenerate-input behaviour is ruled on individually by ADR-015. A metric may return a value for degenerate input **only** where that value is genuinely the answer — documented, tested, and distinguishable:
+
+| Metric | Degenerate input | Behaviour |
+|---|---|---|
+| `MCR_point` / `MCR_sample` | `mean(y_true) == 0` | **Documented sentinel** — `inf` if `mean(y_pred) > 0`, `nan` if both are 0. A zero-truth group is a property of conflict data, not a fault. |
+| `Pearson` | either series constant | **Documented sentinel** — `nan`. Same category as `MCR`: a constant series is a fact about the data (or, for a constant prediction series, a finding about the model — it is a baseline), not a broken invariant (C-22). |
+| `Ignorance` | observation outside the configured `bins` | **Raises**, naming the value and the range. Here the *configuration* is wrong — the profile's bins do not cover the target's domain — so this is a fault, not a data property (C-27, C-28a). |
+
+The dividing line is **fault vs data property**, not whether the returned number "is an answer". `MCR` and `Pearson` sit together because both degenerate cases are caused by data with no variation; `Ignorance` is separate because a mis-scoped bin range is a configuration error.
+
+A raise here propagates to the entire `evaluate()` call — every metric, every schema. Before ruling that a degenerate case must raise, check which legitimate workflow that makes impossible. Ruling on `Pearson` was reversed on exactly this point: it aborted any evaluation of a constant baseline, which ADR-041 requires as routine.
+
+Deleting a test that asserts a permitted sentinel violates ADR-015 criterion 3 — it is not a test-cleanup decision.
 
 ---
 

--- a/documentation/CICs/MetricFrame.md
+++ b/documentation/CICs/MetricFrame.md
@@ -1,0 +1,165 @@
+# Class Intent Contract: MetricFrame
+
+**Status:** Active  
+**Owner:** Evaluation Core  
+**Last reviewed:** 2026-08-02  
+**Related ADRs:** views-frames ADR-020 (contract home), ADR-041 (Output Schema), ADR-013 (Observability), ADR-015 (Degenerate/Empty Results), ADR-011 (Topology)  
+
+---
+
+## 1. Purpose
+
+The **evaluation-of-record**: a typed, transportable, provenance-stamped container of evaluation metric values, and the artifact `views-reporting` and `views-pipeline-core` consume instead of scraping WandB.
+
+It is a string-keyed value object — **not** a spatiotemporal `(time, unit)` frame — keyed by the axes `(eval_type, target, metric, group_id, partition, level)`. It exposes the shared views-frames "frame envelope" surface (`values` float32 with an explicit trailing axis, `n_rows`, and a `save`/`load` round-trip) so a consumer can validate it with `views_frames.conformance.assert_frame_envelope` rather than re-asserting a drifting local copy.
+
+---
+
+## 2. Non-Goals (Explicit Exclusions)
+
+- This class does **not** compute metrics — it carries values already computed by `NativeEvaluator`.
+- This class does **not** decide *what* to emit; `EvaluationReport.to_metric_frame()` owns flattening and aggregation.
+- This class does **not** render reports, format for humans, or produce JSON/HTML summaries (ADR-041).
+- This class does **not** know about DataFrames.
+- This class does **not** validate that its contents are *meaningful* — only that they are structurally well-formed. A frame of all-NaN values is valid here; whether that should ever have been emitted is the emit site's concern.
+
+---
+
+## 3. Responsibilities and Guarantees
+
+- **Envelope Conformance:** Guarantees `values` is a `float32` array of shape `(N, 1)` — an explicit trailing axis, never a bare 1-D array — and that every axis in `AXES` is present as a 1-D array of length `N`. This is what makes `assert_frame_envelope` pass.
+- **Complete Key Space:** Guarantees all six axes are present. `partition` and `level` may be empty strings (reporting does not key on them), but the columns exist so the key space is complete.
+- **Provenance Split (views-frames ADR-020, register C-47):** Guarantees generic identity (`model`, `run_id`, `data_version`, `run_type`, `timestamp`, `seed`) lives in the reused `views_frames.FrameMetadata`, while evaluation-specific identity (`scoring_code_version`, `evaluation_timestamp`) stays in `MetricFrameMetadata` and **never leaks into the generic header**.
+- **Round-Trip Fidelity:** Guarantees `load(save(x))` reconstructs an equivalent frame, including numpy-typed metadata scalars.
+- **Fail-Loud Construction:** Guarantees structural violations raise at construction, never later (ADR-013).
+- **Level-1 Observability:** Guarantees every structural failure is logged at `ERROR` **before** raising. Unlike Level-0 components, this class maintains its own logger — it persists an audit record and there is no orchestrator between it and the filesystem (logging standard §5.1).
+
+---
+
+## 4. Inputs and Assumptions
+
+- **`values`**: `np.ndarray`, dtype `float32`, shape `(N, 1)`. `NaN` **is permitted** — see §6.
+- **`identifiers`**: dict containing exactly the keys in `AXES`, each a 1-D length-`N` array of strings.
+- **`metadata`**: optional `MetricFrameMetadata`; defaults to an empty one.
+- **Assumes** the caller has already decided what belongs in the frame. Construction is a structural gate, not a semantic one.
+- **Requires** the optional `views-frames` dependency (`pip install views-evaluation[frames]`). The module is import-gated in `views_evaluation/__init__.py` on `find_spec`, so the core API stays importable without it (ADR-011 minimal core).
+
+---
+
+## 5. Outputs and Side Effects
+
+- **`n_rows`** (property): row count.
+- **`save(directory)`**: **writes three files to disk** — `values.npy`, `identifiers.npz`, `metadata.json`. Creates the directory if absent. This is the one place `views-evaluation` performs I/O (ADR-041 §2).
+- **`load(directory)`** (classmethod): reconstructs a frame written by `save`. Loads with `allow_pickle=False`.
+- **`MetricFrameMetadata.to_dict()` / `.from_dict()`**: flatten and reconstruct provenance, routing generic keys to `FrameMetadata`.
+
+---
+
+## 6. Failure Modes and Loudness
+
+All raise `ValueError` at construction, each logged at `ERROR` first:
+
+- `values` is not a numpy array.
+- `values` is not `float32`.
+- `values` is not 2-D.
+- Any axis in `AXES` is missing from `identifiers`.
+- Any identifier is not 1-D.
+- Any identifier length does not match `values.shape[0]`.
+
+`_json_default` raises `TypeError` (logged) for a metadata value it cannot serialise.
+
+### NaN is permitted — deliberately
+
+`values` may contain `NaN`, meaning *"this metric was not calculated for this group"*. This is **not** a fail-loud violation:
+
+- `load()` must faithfully reconstruct whatever `save()` wrote, including historical frames.
+- The `group_id="mean"` aggregate row carries `nanmean` semantics by design.
+- Accepted sentinels upstream (`MCR`'s `inf`/`nan`, `Pearson`'s `nan`) legitimately reach here.
+
+ADR-015 **ruling 3** rules on this explicitly: the guard against a *vacuous* record belongs at the emit site (`to_metric_frame` raises when no schema produced any value), not in the container, because the emit site has the context to say *why* it was empty. Tightening the container would break the round-trip and change a published cross-repo envelope.
+
+### Zero rows are permitted
+
+A zero-row frame is constructible and loadable, for the same round-trip reason. `to_metric_frame()` will not *emit* one.
+
+---
+
+## 7. Boundaries and Interactions
+
+- **Upstream:** produced solely by `EvaluationReport.to_metric_frame()`.
+- **Downstream:** consumed by `views-reporting` (renders the `group_id="mean"` rows) and `views-pipeline-core`.
+- **Substrate:** reuses `views_frames.FrameMetadata` and is validated by `views_frames.conformance.assert_frame_envelope`.
+- **Level:** this is a **Level 1** component. It may perform I/O; Level 0 may not.
+- **Isolation:** must not import pandas, and must not reach back into `NativeEvaluator` or the metric kernels.
+
+---
+
+## 8. The Cross-Repo Contract
+
+The following are **load-bearing for other repositories**. Changing any of them is a breaking change requiring coordination with views-reporting and views-pipeline-core (register **C-24**, governed by ADR-022):
+
+| Element | Value |
+|---|---|
+| Axes | `(eval_type, target, metric, group_id, partition, level)` |
+| Aggregate row key | `MEAN_GROUP_ID` = `"mean"` |
+| `eval_type` vocabulary | `month-wise`, `time-series-wise`, `step-wise` (via `SCHEMA_TO_EVAL_TYPE`) |
+| Metric tokens | must remain valid names in `METRIC_MEMBERSHIP` |
+| Serialization | `values.npy` + `identifiers.npz` + `metadata.json` |
+| `values` dtype | `float32` |
+
+Only the **metric-token** half is currently CI-guarded (`tests/test_metric_frame.py::TestCanonicalTokenDriftGuard`). The axes, vocabulary, `MEAN_GROUP_ID` and serialization format are **unguarded** — that gap is register **C-24**.
+
+---
+
+## 9. Examples of Correct Usage
+
+```python
+report = evaluator.evaluate(ef)
+mf = report.to_metric_frame(
+    model_id="purple_alien", run_id="abc123", data_version="v7",
+    partition="calibration", level="pgm",
+)
+assert_frame_envelope(mf)          # views-frames conformance
+mf.save("/path/to/run/evaluation")
+later = MetricFrame.load("/path/to/run/evaluation")
+```
+
+---
+
+## 10. Examples of Incorrect Usage
+
+- Constructing a `MetricFrame` by hand instead of via `to_metric_frame()` — the emit path owns aggregation and provenance.
+- Passing `float64` values, or a 1-D `values` array — both raise; the trailing axis is part of the envelope.
+- Putting `scoring_code_version` or `evaluation_timestamp` into `FrameMetadata` — they belong in `MetricFrameMetadata` (C-47).
+- Inferring `model_id`/`run_id`/`data_version` inside this library. All identity is **injected** by the caller; `run_id` may legitimately be `None` at emit time, when the WandB run does not yet exist.
+- Aggregating `values` across groups with `mean` rather than `nanmean` — permitted `NaN`s will poison the result.
+- Treating `schema_version` as enforced on `load()`. It is written but **not** checked (register **C-26**).
+
+---
+
+## 11. Test Alignment
+
+- **Green:** `tests/test_metric_frame.py::TestToMetricFrameGreen` — emit for all four `(task, pred_type)` cells, envelope conformance, save/load round-trip, vocabulary mapping, provenance split, mean aggregate rows.
+- **Beige:** `TestToMetricFrameBeige` — empty individual schema, NaN values, `run_id=None`, default `scoring_code_version`, zero-row container conformance.
+- **Red:** `TestMetricFrameConstructionRed` — non-float32, wrong ndim, missing axis, length mismatch, non-array, 2-D identifier.
+- **Red (loudness):** `TestMetricFrameLogAndRaiseRed` — log-and-raise pairing, identical log/exception message, and the Level-0 exemption asserted in the opposite direction.
+- **Red (emit):** `TestVacuousEmitRed` — the ADR-015 ruling-6 guard.
+- **Drift guard:** `TestCanonicalTokenDriftGuard` — metric tokens against views-reporting's canonical set.
+
+---
+
+## 12. Known Deviations
+
+- **`schema_version` is not enforced on `load()`** — an old frame under a changed format is not rejected loudly. Register **C-26**; the cross-repo wire-contract half of views-frames C-46 is open and is this repo's responsibility.
+- **float64 → float32 cast at emit.** Metric values are computed in float64 and narrowed for the envelope, so the persisted record is less precise than the computed metric. Register **C-26**.
+- **`scoring_code_version` may be ambiguous.** It is the installed package version, not a git SHA (unavailable in a wheel), so two builds of the same version stamp identically. Register **C-25**.
+- **Most of the cross-repo contract in §8 is unguarded by CI.** Register **C-24**.
+
+---
+
+## End of Contract
+
+This document defines the **intended meaning** of `MetricFrame`.
+
+Changes to behavior that violate this intent are bugs.  
+Changes to intent must update this contract — and, because §8 is consumed by other repositories, must be coordinated with them.

--- a/documentation/CICs/NativeEvaluator.md
+++ b/documentation/CICs/NativeEvaluator.md
@@ -2,8 +2,8 @@
 
 **Status:** Active  
 **Owner:** Evaluation Core  
-**Last reviewed:** 2026-04-04
-**Related ADRs:** ADR-010 (Ontology), ADR-011 (Topology), ADR-032 (Schemas), ADR-042 (Metric Catalog)
+**Last reviewed:** 2026-08-02  
+**Related ADRs:** ADR-010 (Ontology), ADR-011 (Topology), ADR-015 (Degenerate/Empty Results), ADR-032 (Schemas), ADR-042 (Metric Catalog)
 
 ---
 
@@ -26,7 +26,8 @@ A stateless "Pure Math" engine that executes the three standard Views evaluation
 
 - **Schema Preservation**: Guarantees that month-wise, sequence-wise, and step-wise regrouping logic is consistent with established Views standards (ADR-032).
 - **Stateless Execution**: Operates as a pure function of (Configuration + EvaluationFrame).
-- **Legacy Compatibility**: Provides an explicit `legacy_compatibility` flag (default `True`) that caps step-wise evaluation to the shortest sequence in the frame, reproducing the historic zip-truncation behaviour required for parity with the legacy system. Set `False` to evaluate all steps with available data.
+- **Config Validation at Construction**: Guarantees that a structurally invalid config fails at `__init__`, not at `evaluate()`. Rejects unknown/misspelled keys (validated against `EvaluationConfig`), a missing or empty `steps` list, non-positive step positions, absence of any target list, a declared task with no metrics, and metric names that are unknown or invalid for the cell their key declares. Nothing is defaulted or repaired (ADR-015).
+- **Legacy Compatibility**: Provides an explicit `legacy_compatibility` flag (**default `False`**) that caps step-wise evaluation to the shortest sequence in the frame, reproducing the historic zip-truncation behaviour required for parity with the legacy system. If truncation would drop a step that `config['steps']` explicitly requested, it **raises** rather than returning an empty placeholder for it (ADR-015 ruling 7).
 - **Exact Step Filtering**: Evaluates only the step positions explicitly declared in `config['steps']`. Sparse configs (e.g. `[1, 3, 6, 12]`) produce exactly four step keys, not one key per step up to the maximum.
 - **Fail-Loud Dispatch**: Guarantees that it fails immediately if a requested metric or configuration is invalid for the provided data.
 
@@ -41,7 +42,7 @@ A stateless "Pure Math" engine that executes the three standard Views evaluation
   - `regression_point_metrics`, `regression_sample_metrics`, etc. (List[str]): Metrics to compute
   - `evaluation_profile` (str, default `"base"`): Named profile for metric hyperparameters (ADR-042)
   - `metric_hyperparameters` (Dict[str, Dict[str, Any]]): Per-metric overrides, takes precedence over profile
-- **Identifier Presence**: Assumes `time`, `origin`, and `step` identifiers exist in the frame.
+- **Identifier Presence**: Assumes `time`, `unit`, `origin`, and `step` identifiers exist in the frame — all four are enforced by `EvaluationFrame._validate`. (`unit` is required for construction but is not itself a grouping axis.)
 
 ---
 
@@ -54,9 +55,26 @@ A stateless "Pure Math" engine that executes the three standard Views evaluation
 
 ## 6. Failure Modes and Loudness
 
-- Raises `ValueError` if the target name in metadata is not declared in the config.
-- Raises `ValueError` if a requested metric name is not valid for the task type, or is defined but not yet implemented.
-- Fails loud if the `EvaluationFrame` lacks the required identifiers for a schema.
+At construction (`__init__`) — all `ValueError` (ADR-015 rulings 4/5, risk register C-02):
+
+- Config is not a dict.
+- Unknown evaluation profile name.
+- Unknown or misspelled config key, including any legacy key removed in 0.4.0.
+- `steps` missing or empty; or containing a non-integer or non-positive entry.
+- No target list declared.
+- A declared task with no metrics for it.
+- A metric name absent from `METRIC_CATALOG`, or not valid for the `(task, pred_type)` cell its key declares.
+
+At evaluation (`evaluate`) — all `ValueError`:
+
+- The target in frame metadata is not declared in the config.
+- No metrics configured for the resolved `(task, pred_type)`. This can only be detected here, because `pred_type` is a property of the frame (`n_samples > 1`), not of the config.
+- A requested metric is defined but not yet implemented.
+- `legacy_compatibility=True` would truncate away a step that `config['steps']` explicitly requested.
+- A metric function raises — wrapped and re-raised naming the metric, task and pred_type (C-16).
+- The `EvaluationFrame` lacks the required identifiers for a schema.
+
+**Loudness note:** this class is Level 0 and maintains **no logger** — exceptions propagate to the orchestrator (logging standard §5.1). That is deliberate; adding a logger here is a violation.
 
 ---
 
@@ -71,8 +89,8 @@ A stateless "Pure Math" engine that executes the three standard Views evaluation
 ## 8. Examples of Correct Usage
 
 ```python
-evaluator = NativeEvaluator(config)
-report = evaluator.evaluate(ef, legacy_compatibility=True)  # returns EvaluationReport
+evaluator = NativeEvaluator(config)          # raises now if config is structurally invalid
+report = evaluator.evaluate(ef)              # legacy_compatibility defaults to False
 
 # Access results
 month_df = report.to_dataframe('month')        # pd.DataFrame indexed by group keys
@@ -88,6 +106,8 @@ schema = report.get_schema_results('time_series')  # dict → typed metrics data
 - Requesting metrics that are not valid for the (task, pred_type) combination — e.g. asking for `CRPS` on a point prediction. This will fail loud.
 - Omitting `evaluation_profile` from config and expecting hardcoded defaults — the resolver requires explicit profile selection.
 - Using `legacy_compatibility=False` without understanding that step-wise results will include steps not present in all origins.
+- Using `legacy_compatibility=True` while requesting more steps in `config['steps']` than the shortest origin sequence supplies — this raises. Request only the steps that should be scored.
+- Relying on a misspelled or legacy config key being ignored — every key is now validated at construction.
 
 ---
 
@@ -102,8 +122,10 @@ schema = report.get_schema_results('time_series')  # dict → typed metrics data
 
 ## 11. Evolution Notes
 
-- `legacy_compatibility` default was flipped to `False` in Phase 3. The flag is retained for callers that need truncation behavior.
-- Config validation may be added to `__init__` to catch structural config errors at construction time rather than at evaluation time (currently a known gap — risk register C-02).
+- `legacy_compatibility` default was flipped to `False` in Phase 3. The flag is retained for callers that need truncation behavior. (§3 of this contract incorrectly stated the default was `True` until 2026-08-02.)
+- Config validation added to `__init__` (2026-08-02, C-02): structural config errors now surface at construction rather than at evaluation. The valid key set is derived from `EvaluationConfig.__annotations__`, giving that previously type-only module a runtime authority. Tests: `TestNativeEvaluatorRed` (9 cases).
+- Empty-metric-list guard added to `_resolve_task_and_metrics` (2026-08-02, C-02): a resolved `(task, pred_type)` with no configured metrics now raises instead of returning empty per-group dicts.
+- `legacy_compatibility` truncation made loud (2026-08-02, C-20): requesting a step that truncation would drop now raises. Previously such steps were returned as empty placeholder dicts.
 - The `EvaluationReport` return type is stable; the internal `_calculate_metrics` dispatch may evolve as the `MetricCatalog` grows.
 - Exception wrapping added to `_calculate_metrics()` (2026-04-04, C-16): metric function exceptions are now caught and re-raised as `ValueError` naming the metric, task, and pred_type. Test: `test_metric_function_error_includes_metric_name`.
 - Step sentinel changed from hardcoded `999` to `float('inf')` (2026-04-04, C-17): steps >= 1000 are no longer silently dropped. Test: `test_step_values_above_999_not_silently_dropped`.
@@ -112,7 +134,6 @@ schema = report.get_schema_results('time_series')  # dict → typed metrics data
 
 ## 12. Known Deviations
 
-- **No config validation at init:** `NativeEvaluator.__init__` only validates the profile name. Missing or malformed config keys cause cryptic errors at evaluation time rather than at construction. (Risk register C-02)
 - **sklearn/scipy in "pure core":** The `NativeEvaluator` dispatches to metric functions that import `sklearn` and `scipy` at module level. This contradicts the stated goal of a zero-external-dep Level 0 core (ADR-011). (Risk register C-05)
 
 ---

--- a/documentation/CICs/NativeEvaluator.md
+++ b/documentation/CICs/NativeEvaluator.md
@@ -26,7 +26,9 @@ A stateless "Pure Math" engine that executes the three standard Views evaluation
 
 - **Schema Preservation**: Guarantees that month-wise, sequence-wise, and step-wise regrouping logic is consistent with established Views standards (ADR-032).
 - **Stateless Execution**: Operates as a pure function of (Configuration + EvaluationFrame).
-- **Config Validation at Construction**: Guarantees that a structurally invalid config fails at `__init__`, not at `evaluate()`. Rejects unknown/misspelled keys (validated against `EvaluationConfig`), a missing or empty `steps` list, non-positive step positions, absence of any target list, a declared task with no metrics, and metric names that are unknown or invalid for the cell their key declares. Nothing is defaulted or repaired (ADR-015).
+- **Config Validation at Construction**: Guarantees that a structurally invalid config fails at `__init__`, not at `evaluate()`. Rejects legacy keys removed in 0.4.0 (an enumerated set, matched by exact name), keys that closely resemble a real evaluation key (a suspected typo), a missing or empty `steps` list, non-positive step positions, absence of any target list, a declared task with no metrics, and metric names that are unknown or invalid for the cell their key declares. Nothing is defaulted or repaired (ADR-015).
+- **Never Infers Intent**: A suspected typo is **reported and refused, never substituted**. The evaluator does not guess which key the caller meant and proceed — that is the silent repair ADR-015 forbids. This applies equally to legacy keys, which are named and rejected rather than translated.
+- **Tolerates Foreign Config Keys**: Unrecognised keys that do **not** resemble an evaluation key are ignored, not rejected. `views-pipeline-core` passes its whole *combined* model config through (`NativeEvaluator(context.configs)`), so the dict legitimately carries meta, hyperparameter, deployment and sweep keys — `batch_size`, `algorithm`, `regression_point_baselines` and so on. This tolerance is a **deliberate constraint, not laxity**: see register **C-33**, and do not tighten it without first separating the configs upstream.
 - **Legacy Compatibility**: Provides an explicit `legacy_compatibility` flag (**default `False`**) that caps step-wise evaluation to the shortest sequence in the frame, reproducing the historic zip-truncation behaviour required for parity with the legacy system. If truncation would drop a step that `config['steps']` explicitly requested, it **raises** rather than returning an empty placeholder for it (ADR-015 ruling 7).
 - **Exact Step Filtering**: Evaluates only the step positions explicitly declared in `config['steps']`. Sparse configs (e.g. `[1, 3, 6, 12]`) produce exactly four step keys, not one key per step up to the maximum.
 - **Fail-Loud Dispatch**: Guarantees that it fails immediately if a requested metric or configuration is invalid for the provided data.
@@ -59,7 +61,8 @@ At construction (`__init__`) — all `ValueError` (ADR-015 rulings 4/5, risk reg
 
 - Config is not a dict.
 - Unknown evaluation profile name.
-- Unknown or misspelled config key, including any legacy key removed in 0.4.0.
+- A legacy config key removed in 0.4.0 (`targets`, `metrics`, `*_uncertainty_metrics`) — named and rejected, never translated.
+- A key closely resembling a real evaluation key (suspected typo) — named and rejected, never substituted. Keys that do not resemble one are ignored (C-33).
 - `steps` missing or empty; or containing a non-integer or non-positive entry.
 - No target list declared.
 - A declared task with no metrics for it.

--- a/documentation/CICs/README.md
+++ b/documentation/CICs/README.md
@@ -54,6 +54,7 @@ Contracts must be clear enough that:
 - `NativeEvaluator.md` — Pure math evaluation engine
 - `EvaluationReport.md` — Structured result container
 - `MetricCatalog.md` — Genome registry and parameter resolver
+- `MetricFrame.md` — Evaluation-of-record; the cross-repo emit artifact
 
 ---
 

--- a/documentation/standards/logging_and_observability_standard.md
+++ b/documentation/standards/logging_and_observability_standard.md
@@ -125,7 +125,19 @@ The following must be logged:
 * Configuration summaries
 * All structural failures
 
-> **Scope note:** Level 0 pure-math classes (`EvaluationFrame`, `NativeEvaluator`, `EvaluationReport`) rely on exception propagation per ADR-013 and do not maintain their own loggers. Logging responsibility for these components sits at the orchestration layer (e.g. calling code in `views-pipeline-core` or equivalent orchestrators).
+> **Scope note (revised 2026-08-02):** logging responsibility in this repository splits by architectural level (ADR-011). The split is stated positively below so it cannot be re-derived by guesswork as new components are added — the previous wording named three classes and predated `MetricFrame`, which left Level 1 uncovered by omission rather than by decision.
+>
+> **Level 0 — exempt. Must NOT maintain loggers.**
+> `evaluation_frame.py`, `native_evaluator.py`, `evaluation_report.py`, `metric_catalog.py`, `native_metric_calculators.py`.
+> These are pure math and pure registry. They compute and validate; they do not act on the world. They rely on exception propagation per ADR-013, and logging responsibility sits at the orchestration layer (e.g. `views-pipeline-core`). Adding a logger here is a violation, not an improvement: it would duplicate what the orchestrator already records and put I/O in the numeric core.
+>
+> **Level 1 — must log at `ERROR` before raising.**
+> `metric_frame.py`, and the `EvaluationReport.to_metric_frame()` emit path.
+> These produce the **evaluation-of-record**: a persisted, cross-repo audit artifact written to disk by `MetricFrame.save()`. There is no orchestrator between this code and the filesystem, and a failure here means an audit record was not written or was written wrong. That must leave a trace independent of whether the caller catches the exception.
+>
+> **The `to_metric_frame()` exception.** The emit path's `ImportError` guard physically resides in `evaluation_report.py`, a Level-0 file. It logs anyway, because logging follows the **emit path**, not the file. This is deliberate and is not a precedent for logging elsewhere in that module — no other raise in `evaluation_report.py` logs.
+>
+> **Rule for new components:** a component logs if it performs or persists an observable external effect. If it only computes a value and hands it back, it does not.
 
 ### 5.2 Optional Logging
 

--- a/documentation/standards/physical_architecture_standard.md
+++ b/documentation/standards/physical_architecture_standard.md
@@ -69,10 +69,14 @@ This file bundles heterogeneous concerns:
 1. **Shared utility** (`_guard_shapes`) — used by all metrics, should arguably be its own module or remain as a private helper.
 
 2. **Four metric families:**
-   - Regression point: MSE, MSLE, RMSLE, EMD, Pearson, MTD, y_hat_bar, MCR
-   - Regression sample: CRPS, twCRPS, MIS, QIS, QS_sample, Coverage, Ignorance
-   - Classification point: AP, Brier_point, QS_point
-   - Classification sample: Brier_sample
+   - Regression point: MSE, MSLE, RMSLE, EMD, Pearson, MTD, y_hat_bar, MCR_point, QS_point
+   - Regression sample: CRPS, twCRPS, MIS, QIS, QS_sample, Coverage, Ignorance, y_hat_bar, MCR_sample, Brier_rgs_sample
+   - Classification point: AP, Brier_cls_point
+   - Classification sample: CRPS, twCRPS, Brier_cls_sample, Jeffreys
+
+   `METRIC_MEMBERSHIP` in `metric_catalog.py` is the authoritative version of this
+   mapping; the list above is illustrative. (It listed the pre-PR-#18 names
+   `Brier_point`/`Brier_sample` and misplaced `QS_point` until 2026-08-02.)
 
 3. **Placeholder stubs** for unimplemented metrics (SD, pEMDiv, Variogram, Jeffreys).
 

--- a/documentation/validate_docs.sh
+++ b/documentation/validate_docs.sh
@@ -51,21 +51,43 @@ if [ -f "CICs/README.md" ]; then
     done < <(grep -E '^- `[A-Z].*\.md`' CICs/README.md 2>/dev/null | grep -v '>' || true)
 fi
 
-# 3. Cross-ADR reference integrity (constitutional ADRs 000-009 only;
-#    higher numbers are project-specific and not expected in the template repo)
-echo "--- Checking cross-ADR references (constitutional: 000-009) ---"
+# 3. Cross-ADR reference integrity — ALL local ADRs (000-999), not just the
+#    constitutional 00x band. Widened 2026-08-02: the previous 00x-only scope meant
+#    a reference to any project ADR (010+) was unverified, so ADR-042 sat unindexed
+#    and ADR-015's references went unchecked. See register C-34.
+#
+#    ADRs owned by OTHER repos are referenced here deliberately (e.g. views-frames
+#    ADR-020 is the MetricFrame contract home) and must not be flagged, so a
+#    reference qualified by a repo name is skipped.
+echo "--- Checking cross-ADR references (all local ADRs) ---"
 while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue
     file=$(echo "$ref" | cut -d: -f1)
-    adr_num=$(echo "$ref" | grep -oP 'ADR-00\K[0-9]' | head -1)
-    if [ -n "$adr_num" ]; then
-        match_count=$(find ADRs -name "00${adr_num}_*.md" 2>/dev/null | wc -l)
+    line=$(echo "$ref" | cut -d: -f3-)
+    # STRIP cross-repo references ("views-frames ADR-020", "views-reporting ADR-029")
+    # rather than skipping the whole line. Skipping swallowed any local reference that
+    # shared a line with a cross-repo one — a silent blind spot in a checker whose job
+    # is finding blind spots (found by review-diff, 2026-08-02).
+    line=$(echo "$line" | sed -E 's/(views-[a-z-]+|pipeline-core)[[:space:]]+ADR-[0-9]{3}//g')
+    for adr_num in $(echo "$line" | grep -oP 'ADR-\K[0-9]{3}'); do
+        match_count=$(find ADRs -name "${adr_num}_*.md" 2>/dev/null | wc -l)
         if [ "$match_count" -eq 0 ]; then
-            echo "  ERROR: $file references ADR-00${adr_num} but no matching file found"
+            echo "  ERROR: $file references ADR-${adr_num} but no matching file found"
             errors=$((errors + 1))
         fi
+    done
+done < <(grep -rn 'ADR-[0-9][0-9][0-9]' --include='*.md' . 2>/dev/null || true)
+
+# 3b. Every ADR on disk must be indexed in ADRs/README.md
+echo "--- Checking ADR index completeness ---"
+for adr in ADRs/[0-9]*.md; do
+    name=$(basename "$adr")
+    [[ "$name" == *template* ]] && continue
+    if ! grep -q "$name" ADRs/README.md 2>/dev/null; then
+        echo "  ERROR: $name exists but is not indexed in ADRs/README.md"
+        errors=$((errors + 1))
     fi
-done < <(grep -rn 'ADR-00[0-9]' --include='*.md' . 2>/dev/null || true)
+done
 
 # 4. Check that referenced protocol files exist
 echo "--- Checking protocol file references ---"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 python = ">=3.11,<3.15"
 scikit-learn = "^1.6.0"
 numpy = "^1.26.4"
+scipy = "^1.11"  # Load-time dep of native_metric_calculators (EMD, Pearson) — not merely transitive via sklearn
 pandas = {version = "^1.5.3", optional = true}
 views-frames = {version = "^1.4", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "views_evaluation"
-version = "0.4.0"
+version = "0.5.0"
 description = ""
 authors = [
     "Xiaolong Sun <xiaolong.sun@pcr.uu.se>",

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,82 +1,63 @@
 # Technical Risk Register — views-evaluation
 
-**Last updated:** 2026-06-26
-**Total open concerns:** 9
+**Last updated:** 2026-08-02
+**Total open concerns:** 7
 **Governing ADR:** ADR-023
+
+> **2026-08-02 — Fail-Loud Doctrine epic (#26) closed 10 concerns.** ADR-015 (Degenerate
+> and Empty Results) was written and applied; ADR-022 (Evolution and Stability) was
+> activated. Clusters A, B and F are closed; C and E are reduced. The
+> register went from 15 open concerns to 7. (C-28 remains open in reduced form: its
+> inert `low_bin`/`high_bin` params were kept as documented reserved placeholders
+> rather than deleted — a maintainer decision on 2026-08-02.)
 
 ---
 
 ## Causal Clusters
 
-Root-cause groupings of the open concerns (added 2026-06-26, strategic review). Fixing the root addresses the listed symptoms together.
+Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 by epic #26). Closed clusters are retained as a record of what the root cause was and how it was resolved.
 
-- **Cluster A — Fail-Loud violations / silent degradation** → **C-02, C-20, C-22.** The codebase espouses ADR-013 Fail-Loud, yet has output paths that emit empty/omitted/`nan` values unflagged. A single audit of metric/output paths (make loud, or document explicit sentinels à la MCR) addresses all three. **Highest priority** — holds both borderline-Tier-1 entries (C-02, C-20).
-- **Cluster B — EvaluationManager-deletion fallout / unowned config validation** → **C-02.** Phase-3 removal of `EvaluationManager` left config validation unowned. **C-02 is the keystone** (also in Cluster A). _(The dangling-docstring symptom, formerly C-21, was demoted to the tech-debt backlog on 2026-06-26.)_
-- **Cluster C — scipy/sklearn in the Level-0 core** → **C-05, C-19.** `native_metric_calculators.py` imports scipy/sklearn at module level in a nominally pure-numpy core: ADR-011 purity violation (C-05) + undeclared packaging dep (C-19). Latent — no current trigger.
-- **Cluster D — MetricFrame evaluation-of-record integrity** → **C-24, C-25, C-26.** The newly-emitted cross-repo artifact (`to_metric_frame` / `MetricFrame`) has three exposures on a young, not-yet-hardened surface: contract drift breaking consumers (C-24), a misleading provenance version-label (C-25), and float32 / `schema_version` fidelity gaps (C-26). Consumers (views-reporting, pipeline-core) are actively building against it.
+- **Cluster A — No doctrine for degenerate or empty results (Fail-Loud violations)** → **RESOLVED 2026-08-02**, one accepted residue (**C-22**). **ADR-015** now defines what a computation does when it cannot produce a result and rules on every non-raising path individually, on a **fault-vs-data-property** test. C-02, C-28(a), C-29, C-30, C-32 closed; C-20's truncation half closed. **C-22 remains open as an accepted, documented sentinel rather than a defect** — Pearson's `nan` was ruled a raise and reversed the same day when the raise proved to abort any evaluation of a constant baseline. The cluster's root cause is gone; what is left is a contract, not a silence.
+- **Cluster B — Phase-3 deletion left config validation and its documented contracts unowned** → **CLOSED 2026-08-02.** `NativeEvaluator._validate_config` (#31) restored ownership of config validation, deriving the valid key set from `EvaluationConfig` so the schema has one authority; the README was corrected (#38) and a documentation-contract test now guards it (#40). Former members C-02, C-29 closed (+ previously demoted C-21, C-23).
+- **Cluster C — scipy/sklearn in the Level-0 core** → **C-05** (reduced from C-05 + C-19). The *declaration* half closed on 2026-08-02 (#29 declared `scipy` in `pyproject.toml`, C-19). The **ADR-011 purity violation remains open**: `native_metric_calculators.py` still imports `sklearn.metrics` and `scipy.stats` at module level. Latent — no current trigger, and a scope-3 reimplementation to fix.
+- **Cluster D — MetricFrame evaluation-of-record integrity** → **C-24, C-25, C-26** (reduced from four). The vacuous-emit exposure (C-30) closed on 2026-08-02 (#34). The remaining three were deliberately deferred until **after** 0.5.0 ships, so the drift guards pin the contract that actually shipped rather than a moving one. Consumers (views-reporting, pipeline-core) are actively building against this surface.
+- **Cluster E — `Ignorance` bin contract is unsound** → **C-28** (reduced). #32 guards both tails of the bin range, raising per ADR-015 ruling 8 — C-27 closed and C-28's silent-mis-scoring half with it. What remains is **C-28(b)**: `low_bin`/`high_bin` are declared, required, and inert. Kept as documented reserved placeholders by maintainer decision rather than deleted (#33 reverted), so the cluster stays open on a use-it-or-lose-it basis.
+- **Cluster F — Input-boundary shape contract incomplete** → **CLOSED 2026-08-02.** #36 added the `y_true.ndim` check at the frame boundary and the missing `_guard_shapes` call in `y_hat_bar`. C-31, C-32 closed. (C-32 was fixed rather than demoted — the demotion recommendation from the 2026-08-02 strategic review is superseded.)
 
 ---
 
 ## Open Concerns
 
-### C-02 — NativeEvaluator does not validate config at init
-- **Tier:** 2 (High) — upgraded from 3 (2026-04-04); borders Tier 1 via the silent-no-op path below
-- **Description:** `NativeEvaluator.__init__` only validates the profile name. Missing or malformed config keys cause failures at evaluation time, not at construction. Two distinct failure modes exist: (a) missing target lists raise a loud `ValueError` ("Target X not found"); but (b) a **missing or misspelled metric-list key silently produces empty results with no error signal** — `_resolve_task_and_metrics` reads `config.get(f"{task}_{pred_type}_metrics", [])` (`native_evaluator.py:52`), so a typo like `regression_sample_metric` returns `[]`, and `evaluate()` returns an `EvaluationReport` with empty per-group dicts that looks successful. `config_schema.py` is a `TypedDict(total=False)` with zero runtime enforcement, and the documented validator (`EvaluationManager._validate_config`) was deleted in Phase 3, leaving config validation unowned.
-- **Trigger:** A caller passes a config whose metric-list key is misspelled or omitted (e.g. `regression_sample_metric`); `evaluate()` returns an empty-but-successful-looking report instead of failing, and the misconfiguration goes unnoticed. (Also: missing `steps`/target lists surface as errors only deep inside `evaluate()`.)
-- **Location:** `native_evaluator.py:28-39` (init), `native_evaluator.py:41-54` (`_resolve_task_and_metrics`, line 52), `config_schema.py` (type-only)
-- **Source:** repo-assimilation (2026-03-31), upgraded 2026-04-04 (risk register review), silent-no-op path added 2026-06-24 (repo-assimilation)
-- **Note:** This directly contradicts the Fail-Loud principle (ADR-013) upheld elsewhere in the codebase. See also C-21 (stale `EvaluationManager` validator reference). Part of causal clusters A + B.
-
----
-
 ### C-05 — sklearn/scipy in pure-math core
 - **Tier:** 3 (Medium)
 - **Description:** `native_metric_calculators.py` imports `sklearn.metrics` and `scipy.stats` at module level. Only 4 metric functions use these (AP, EMD, Pearson, MTD). This contradicts the zero-external-dep goal for Level 0 (ADR-011).
 - **Trigger:** When someone packages views-evaluation as a minimal-dep wheel, or adds a CI/import-lint check asserting Level-0 imports only numpy — the module-level `sklearn`/`scipy` imports fail it.
-- **Source:** repo-assimilation (2026-03-31); trigger sharpened 2026-06-26 (strategic review)
+- **Location:** `views_evaluation/evaluation/native_metric_calculators.py:2-6` (module-level `sklearn.metrics` and `scipy.stats` imports); used by `calculate_ap_native:76`, `calculate_emd_native:83`, `calculate_pearson_native:88`, `calculate_mtd_native:96`
+- **Source:** repo-assimilation (2026-03-31); trigger sharpened 2026-06-26 (strategic review); Location field added 2026-08-02 (strategic review — required field was missing)
 - **Mitigation path:** Replace with pure-numpy implementations or move affected metrics to a Level 1 module.
-- **Note:** See also C-19 — the `scipy` half of these imports is also an *undeclared packaging* dependency, a separate concern from the ADR-011 purity violation tracked here. Part of causal cluster C.
+- **Note:** The packaging half (C-19 — `scipy` undeclared in `pyproject.toml`) was **closed on 2026-08-02** (#29). What remains here is purely the ADR-011 purity violation: the imports are now honestly declared, but they still sit in the Level-0 core. Part of causal cluster C.
 
 ---
 
-### C-13 — No deprecation protocol for public API symbols
-- **Tier:** 2 (High)
-- **Description:** `EvaluationManager` and `PandasAdapter` were deleted in a single PR (PR #16) with no deprecation warning in a prior release. Downstream consumers (views-pipeline-core) had no advance signal. The Phase 4 wrapper existed as a bridge but was deleted in the same commit that merged the purge.
-- **Trigger:** Any future public API symbol deletion (function, class, or module) that a downstream consumer depends on.
-- **Source:** 2026-04-03 incident investigation (6/6 integration tests crashed with `ModuleNotFoundError`)
-- **Mitigation path:** Before deleting any `__all__`-exported symbol, add a `DeprecationWarning` in the previous release. Require one release cycle between deprecation and removal.
+### C-20 — Positional `step` semantics are assumed but enforced nowhere
+- **Tier:** 3 (Medium) — reduced from 2 on 2026-08-02; the silent-truncation half was fixed, leaving only the unenforced-convention half
+- **Description:** The step-wise schema groups rows by the caller-supplied `step` identifier under the convention that step = 1-indexed positional lead time (step 1 = the first month of each origin's forecast window). ADR-040 documents the convention and `CICs/EvaluationFrame.md` §8 explains its consequence, but **nothing validates it**. The adapter that used to synthesise `step` positionally (`PandasAdapter`) was deleted in Phase 3, so the assumption now rests entirely on callers. If a caller supplies `step` meaning something else — an absolute month offset, a 0-indexed position — the step groups are mislabelled and cross-model comparison is invalid, with no signal.
+- **Trigger:** When a new consumer (or a rewritten pipeline-core adapter) constructs an `EvaluationFrame` and populates `step` from something other than the 1-indexed position within an origin sequence — e.g. reusing a calendar offset — the step-wise report is silently mislabelled.
+- **Location:** `views_evaluation/evaluation/native_evaluator.py:102-128` (grouping); `documentation/ADRs/040_evaluation_input_schema.md` (the documented convention); `documentation/CICs/EvaluationFrame.md` §8
+- **Source:** repo-assimilation (2026-06-24); scope reduced 2026-08-02 after #37 closed the truncation half
+- **Mitigation path:** This is a **cross-repo contract decision**, not a local fix — the producer of `step` lives in views-pipeline-core. Options: validate at the `EvaluationFrame` boundary that each origin's steps form a contiguous 1..n run; or record the convention as an explicit disagreement entry (D-xx) and accept it. Coordinate with pipeline-core before choosing.
+- **Note:** The **silent-truncation half of this entry was resolved on 2026-08-02** (#37, ADR-015 ruling 7): `legacy_compatibility=True` now raises if truncation would drop a step that `config['steps']` explicitly requested, instead of returning it as an empty placeholder dict. Only the semantics half above remains open. This entry is no longer part of causal cluster A.
 
 ---
 
-### C-19 — `scipy` is an undeclared runtime dependency
-- **Tier:** 3 (Medium)
-- **Description:** `native_metric_calculators.py:6` does `from scipy.stats import wasserstein_distance, pearsonr` at module load (used by EMD and Pearson), but `pyproject.toml` declares no `scipy` dependency — only `scikit-learn`, `numpy`, and optional `pandas`. The import succeeds today only because `scipy` is pulled in transitively by scikit-learn (observed: scipy 1.15.1). The dependency is real and load-time, not lazy, so the packaging contract under-declares what the library needs.
-- **Trigger:** When the dependency tree is resolved in an environment where scikit-learn is present without `scipy` (a future sklearn that vendors its math, or a constrained/locked install that satisfies sklearn from a wheel without the scipy transitive), importing `views_evaluation` raises `ImportError` at module load.
-- **Location:** `views_evaluation/evaluation/native_metric_calculators.py:6`; `pyproject.toml` `[tool.poetry.dependencies]`
-- **Source:** repo-assimilation (2026-06-24)
-- **Mitigation path:** Declare `scipy` explicitly in `pyproject.toml`. Distinct from C-05, which concerns Level-0 purity rather than declaration. See also C-05.
-
----
-
-### C-20 — Step-wise schema trusts positional `step` semantics and silently truncates under `legacy_compatibility`
-- **Tier:** 2 (High)
-- **Description:** The step-wise schema groups rows by the caller-supplied `step` identifier (`native_evaluator.py:119`) under the convention that step = 1-indexed positional lead time (step 1 = first month in a sequence). This is documented as a "known semantic risk, matches legacy." Compounding it, when `evaluate(..., legacy_compatibility=True)` is used, steps beyond the shortest origin sequence are **silently dropped** (`native_evaluator.py:111-122`): `max_allowed_step` is set to the minimum per-origin sequence length and longer-horizon steps are skipped with no warning. A consumer comparing models with heterogeneous sequence lengths can silently lose long-horizon evaluation rows.
-- **Trigger:** When a caller evaluates data whose origins have unequal sequence lengths with `legacy_compatibility=True`, the step-wise report omits steps beyond the shortest sequence without any signal; or when `step` encodes something other than positional lead time, step groups are mislabeled.
-- **Location:** `views_evaluation/evaluation/native_evaluator.py:102-128`
-- **Source:** repo-assimilation (2026-06-24)
-- **Mitigation path:** Log dropped steps under truncation; document/validate the positional `step` contract at the `EvaluationFrame` boundary.
-- **Note:** Part of causal cluster A (silent degradation).
-
----
-
-### C-22 — Pearson returns `nan` on constant input with suppressed warning
-- **Tier:** 3 (Medium) — re-tiered from 4 on 2026-06-26 (silent `nan` reachable in normal use, not only adversarial input)
-- **Description:** `calculate_pearson_native` (`native_metric_calculators.py:88-94`) calls `scipy.stats.pearsonr`, which on a constant `y_true` or `y_pred` returns `nan` and emits a `ConstantInputWarning` (observed during the test run for `test_nan_metric_result_is_finite_checkable`). The `nan` flows into the `EvaluationReport` unflagged. Small or single-unit groups (a month with one unit, a short sequence) can be constant, so this is reachable in normal use, not only adversarial input.
-- **Trigger:** When a per-group view (e.g. a single-unit month or a constant-truth sequence) yields constant `y_true`/`y_pred`, the Pearson metric silently records `nan` in the report rather than signalling the degenerate case.
-- **Location:** `views_evaluation/evaluation/native_metric_calculators.py:88-94`
-- **Source:** repo-assimilation (2026-06-24)
-- **Mitigation path:** Decide on an explicit contract for degenerate Pearson groups (raise, or document `nan` as the defined sentinel like `MCR` does at lines 120-122).
-- **Note:** Part of causal cluster A (silent degradation). Re-tiered 4→3 on 2026-06-26.
+### C-22 — `Pearson` records `nan` for degenerate groups (accepted sentinel)
+- **Tier:** 4 (Low) — reduced from 3 on 2026-08-02; the behaviour is now contracted and documented rather than incidental
+- **Description:** `calculate_pearson_native` returns `nan` when either series is constant, and that `nan` flows into the `EvaluationReport` and on into `to_metric_frame()`. This was originally filed because the value appeared unflagged and undocumented. It is now an **explicitly accepted sentinel** under ADR-015 ruling 2, documented in the function docstring in `MCR`'s style, asserted by tests, and recorded in `CICs/MetricCatalog.md`. The residual concern is only that a consumer who does not read the contract may treat `nan` as a computed value.
+- **Trigger:** When a downstream consumer aggregates Pearson across groups without excluding `nan` — e.g. using `mean` rather than `nanmean` — a single degenerate group silently poisons the aggregate to `nan`. (`to_metric_frame()` already uses `nanmean` and is safe; the risk is in consumers that read `to_dict()` directly.)
+- **Location:** `views_evaluation/evaluation/native_metric_calculators.py` (`calculate_pearson_native`); `documentation/CICs/MetricCatalog.md` (degenerate-input table)
+- **Source:** repo-assimilation (2026-06-24); re-tiered 4→3 on 2026-06-26; **ruled a raise then reversed to a sentinel on 2026-08-02** (ADR-015 R2) after the raise was found to abort any evaluation of a constant baseline
+- **Mitigation path:** Accepted as designed. If it needs closing, the route is to document the `nan` contract in the consumer-facing MetricFrame docs so downstream aggregation is provably safe — not to change the metric.
+- **Note:** ⚠ **Do not "fix" this by making Pearson raise.** That was tried on 2026-08-02 and reverted within the day: a "predict zero everywhere" baseline has a constant prediction series, so the raise aborted the entire evaluation run — every metric, every schema — for a workflow ADR-041 requires as routine. `tests/test_native_evaluator.py::test_constant_baseline_model_evaluates_without_crashing` guards against the regression. See ADR-015 R2 for the full reasoning.
 
 ---
 
@@ -86,7 +67,7 @@ Root-cause groupings of the open concerns (added 2026-06-26, strategic review). 
 - **Trigger:** When someone renames/re-tokenizes a metric, changes the MetricFrame axes or `MEAN_GROUP_ID`, edits `SCHEMA_TO_EVAL_TYPE`, or changes `MetricFrame.save`/`load` format, without a matching update in views-reporting / pipeline-core.
 - **Location:** `views_evaluation/evaluation/metric_frame.py`; `views_evaluation/evaluation/evaluation_report.py` (`to_metric_frame`)
 - **Source:** review-rr strategic (2026-06-26), blind-spot analysis
-- **Mitigation path:** Extend the drift-guard test to cover axes / `MEAN_GROUP_ID` / `eval_type` vocabulary / a serialization round-trip; pin the persistence convention jointly with pipeline-core + reporting; enforce `schema_version` at load. See views-reporting C-41 (token drift, consumer side) and C-26 (serialization).
+- **Mitigation path:** Extend the drift-guard test to cover axes / `MEAN_GROUP_ID` / `eval_type` vocabulary / a serialization round-trip; pin the persistence convention jointly with pipeline-core + reporting. (**`schema_version` enforcement at load is owned by C-26(b), not here** — de-duplicated 2026-08-02, as both entries previously claimed the same fix.) See views-reporting C-41 (token drift, consumer side) and C-26 (serialization fidelity).
 - **Note:** Part of causal cluster D (MetricFrame evaluation-of-record). This repo's most consequential cross-repo surface — consumers are actively coding against it.
 
 ---
@@ -105,11 +86,22 @@ Root-cause groupings of the open concerns (added 2026-06-26, strategic review). 
 ### C-26 — MetricFrame emitted-artifact fidelity: float32 cast + unenforced `schema_version`
 - **Tier:** 3 (Medium)
 - **Description:** Two durability gaps in the persisted evaluation-of-record. (a) Metric values are computed in float64 but cast to **float32** for the views-frames envelope (`assert_frame_envelope` requires float32), so the stored record loses precision relative to the computed metric. (b) `MetricFrame` carries a `schema_version` marker (`"1.0.0"`) but `save`/`load` does **not enforce** it — an old frame loaded under a changed format is not rejected loudly (the cross-repo wire-contract half of views-frames **C-46** is open and is this repo's responsibility).
-- **Trigger:** When a metric's precision beyond ~7 significant figures matters for a downstream decision; or when `MetricFrame.save`/`load` format changes and a previously-persisted frame is loaded without a `schema_version` mismatch error.
+- **Trigger:** (a) When two models are ranked on a metric whose float64 values differ by less than the float32 representable gap (~1e-7 relative), the persisted record cannot reproduce the ranking the evaluator computed — check by comparing `to_dict()` values against the emitted `MetricFrame.values` for any near-tie. (b) When `MetricFrame.save`/`load` format changes and a previously-persisted frame is loaded without a `schema_version` mismatch error. _(Trigger (a) rewritten 2026-08-02 — the prior formulation, "when precision beyond ~7 significant figures matters," was unfalsifiable.)_
 - **Location:** `views_evaluation/evaluation/evaluation_report.py` (`to_metric_frame`, float32 cast); `views_evaluation/evaluation/metric_frame.py` (`save`/`load`, `SCHEMA_VERSION`)
 - **Source:** review-rr strategic (2026-06-26), blind-spot analysis
 - **Mitigation path:** Document float32 as the defined precision of the evaluation-of-record (accept), or persist float64 alongside; enforce `schema_version` on load (views-frames C-46 open half). See also C-24.
 - **Note:** Part of causal cluster D.
+
+---
+
+### C-28 — `Ignorance` declares two reserved placeholder params that have no effect
+- **Tier:** 3 (Medium) — reduced scope 2026-08-02; the silent-mis-scoring half (a) was fixed, leaving only the inert-parameter half (b)
+- **Description:** `Ignorance` declares `genome=("bins", "low_bin", "high_bin")`. `resolve_metric_params` treats all three as **required** and fails loud if a profile omits any. But `low_bin` and `high_bin` **have no effect whatsoever**: they are forwarded as `np.histogram_bin_edges(preds, bins=bins, range=(low_bin, high_bin))`, and NumPy **ignores `range` whenever `bins` is a sequence** — which it is in every shipped profile. Verified 2026-08-02: edges computed with `range=(0, 10000)` and `range=(0, 1)` are byte-identical. **Retained deliberately as reserved placeholders for planned work**, not fixed and not deleted — a maintainer decision taken 2026-08-02.
+- **Trigger:** When someone hits the out-of-range failure from ADR-015 ruling 8 and tries to fix it by widening `high_bin` — which will do nothing at all, because only `bins` governs the accepted domain. Or when the planned work that these placeholders exist for is scheduled, at which point the activation spec must be met.
+- **Location:** `views_evaluation/evaluation/native_metric_calculators.py` (`calculate_ignorance_score_native` — status block in the docstring); `views_evaluation/evaluation/metric_catalog.py` (genome declaration); `views_evaluation/profiles/base.py` (values)
+- **Source:** repo-assimilation (2026-08-02), empirically verified; scope reduced 2026-08-02 after #32 fixed half (a); retained as a placeholder by maintainer decision rather than deleted
+- **Mitigation path:** **Use it or lose it.** Either (1) activate them — which requires supporting integer `bins`, raising on the contradictory `bins`-sequence-plus-range case, validating `low_bin < high_bin`, and making ADR-015 ruling 8's error message cite them rather than the computed edges; or (2) delete them from the genome, every profile, and the kernel signature. The full activation spec is in the kernel docstring's status block.
+- **Note:** Guarded against silent drift in **both** directions by `tests/test_metric_catalog.py::TestIgnoranceReservedPlaceholders` — activating them breaks the inertness test, deleting them breaks the genome test. `CICs/MetricCatalog.md` records the four conditions a reserved placeholder must satisfy to remain one; failing any of them, it is dead configuration and must be deleted.
 
 ---
 
@@ -135,11 +127,24 @@ Moved out of the register (no correctness/reliability dimension) — tracked in 
 | C-07 | 4 | Golden-value test coverage incomplete | 17 golden-value tests in `TestGoldenValues` + 8 Brier/QS golden-value tests. AP uses sklearn as oracle. | 2026-04-02 |
 | C-08 | 4 | EvaluationManager config validation diverges from MetricCatalog | EvaluationManager removed in Phase 3. NativeEvaluator is the single evaluator. | 2026-04-01 |
 | C-09 | 4 | `deprecation_msgs.py` appears unused | File removed. No internal or external references found. | 2026-03-31 |
-| C-11 | 3 | pyproject.toml version not bumped for breaking change | Bumped to 0.5.0 in commit `aba663c`. ⚠️ **Regressed (2026-06-26):** version reverted to 0.4.0 (PR #20); re-tracked in open issue #23 (cut 0.5.0). | 2026-04-02 |
+| C-11 | 3 | pyproject.toml version not bumped for breaking change | Bumped to 0.5.0 in commit `aba663c`; regressed to 0.4.0 by PR #20. **Re-fixed 2026-08-02** (#41): `pyproject.toml` is 0.5.0 again, and ADR-022 rule 5 now states the versioning policy that was previously unwritten. | 2026-04-02 |
 | C-12 | 4 | `to_dataframe()` requires undeclared pandas optional dependency | Added `pandas = {version = "^1.5.3", optional = true}` and `[tool.poetry.extras] dataframe = ["pandas"]`. | 2026-04-02 |
-| C-14 | 4 | Editable install metadata stale | Ran `pip install -e ".[dataframe]"` to refresh. `pip show` now reports 0.5.0. ⚠️ **Stale (2026-06-26):** now reports 0.4.0 (version reverted, PR #20); see #23. | 2026-04-04 |
+| C-14 | 4 | Editable install metadata stale | Ran `pip install -e ".[dataframe]"` to refresh; went stale again when PR #20 reverted the version. **Re-fixed 2026-08-02** (#41): reinstalled with `[dataframe,frames]`; `importlib.metadata.version` and the MetricFrame `scoring_code_version` stamp both report 0.5.0. | 2026-04-04 |
 | C-15 | 4 | `to_dataframe()` is the only remaining dataclass consumer | Accepted as design — `to_dataframe()` owns the dataclass-to-DataFrame path internally. No action needed unless metric catalog grows beyond 30 entries. | 2026-04-04 |
 | C-16 | 3 | Metric function exceptions propagate without context | Wrapped `spec.function()` call in `_calculate_metrics()` with try/except that re-raises as `ValueError` naming the metric, task, and pred_type. Test: `test_metric_function_error_includes_metric_name`. | 2026-04-04 |
 | C-17 | 4 | `max_allowed_step = 999` hardcoded sentinel | Changed to `float('inf')`. Steps >= 1000 now correctly evaluated. Test: `test_step_values_above_999_not_silently_dropped`. | 2026-04-04 |
 | C-18 | 4 | No bounds validation on metric hyperparameters | Added bounds validation in `resolve_metric_params()` for `alpha`, `quantile`, `lower_quantile`, `upper_quantile` — all must be in (0, 1). Cross-validation: `lower_quantile < upper_quantile`. 7 tests in `TestResolveMetricParamsBoundsRed`. | 2026-04-04 |
 | C-10 | 4 | `_guard_shapes` dead Pandas handling branches | Removed 22 lines of dead code (pandas extraction, list-in-cell handling). EvaluationFrame._validate() now rejects object-dtype arrays, making these branches unreachable. | 2026-04-04 |
+
+### Closed by the Fail-Loud Doctrine epic (#26), 2026-08-02
+
+| ID | Tier | Description | Resolution | Issue |
+|----|------|-------------|------------|-------|
+| C-02 | **1** | NativeEvaluator does not validate config at init | `_validate_config()` added to `__init__`: rejects unknown/misspelled keys (valid set derived from `EvaluationConfig.__annotations__`), missing/empty/non-positive `steps`, absent target lists, declared tasks with no metrics, and invalid metric names. A resolved `(task, pred_type)` with no metrics now raises at `evaluate()` — the one case that cannot be known at construction. 10 Red tests. | #31 |
+| C-13 | 2 | No deprecation protocol for public API symbols | **ADR-022 activated** (was `Proposed (Deferred)`; its own trigger "breaking changes incur high coordination costs" had fired). Defines the public API surface, a one-release-cycle deprecation contract, the `DeprecationWarning`-vs-fail-loud boundary, `0.x` versioning, a retroactive position on the 0.4.0 removals, and a release checklist as the enforcement point. | #28 |
+| C-19 | 3 | `scipy` is an undeclared runtime dependency | Declared `scipy = "^1.11"` in `pyproject.toml`. It was a load-time import satisfied only transitively via scikit-learn. | #29 |
+| C-27 | 2 | `Ignorance` crashes on observations above the top bin edge | Both tails guarded and raise with a message naming the value and the configured range. Previously `IndexError` above (masked when a prediction was also out of range) and a wrong-bin score below. | #32 |
+| C-29 | 3 | README promises a `DeprecationWarning` no code implements | README corrected: legacy keys were removed in 0.4.0 and now raise at `__init__` as unknown keys. The shim was **not** restored — it had been absent from the published package since 2026-05-18. Guarded against recurrence by `tests/test_documentation_contracts.py`. | #38, #40 |
+| C-30 | 3 | `to_metric_frame()` emits a valid zero-row evaluation-of-record | Emit now raises when no schema has any metric value, naming the target and which schemas were present-but-empty, and logging at `ERROR` first (Level-1 emit path). `MetricFrame` itself still accepts zero rows so `load()` can read back whatever `save()` wrote. | #34 |
+| C-31 | 4 | `EvaluationFrame` does not validate `y_true.ndim` | `y_true.ndim != 1` now raises at construction, placed after the dtype gate so a non-numeric array is still reported as a dtype problem. | #36 |
+| C-32 | 4 | `y_hat_bar` bypasses the shared shape guard | `_guard_shapes` call added, matching every sibling kernel. **Fixed rather than demoted** — this supersedes the demotion recommendation from the 2026-08-02 strategic review. | #36 |

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,17 +1,19 @@
 # Technical Risk Register — views-evaluation
 
 **Last updated:** 2026-08-02
-**Total open concerns:** 8
+**Total open concerns:** 9
 **Governing ADR:** ADR-023
+**Citation convention:** `Location` fields name files and symbols (functions, classes, sections), not line numbers — line numbers drift as soon as anything is inserted above them.
 
 > **2026-08-02 — Fail-Loud Doctrine epic (#26) closed 10 concerns.** ADR-015 (Degenerate
 > and Empty Results) was written and applied; ADR-022 (Evolution and Stability) was
-> activated. Clusters A, B and F are closed; C and E are reduced. The
-> register went from 15 open concerns to 8 (C-33 was opened during the epic:
-> cross-repo inspection found that config validation cannot be strict while
-> pipeline-core passes its whole combined model config through). (C-28 remains open in reduced form: its
-> inert `low_bin`/`high_bin` params were kept as documented reserved placeholders
-> rather than deleted — a maintainer decision on 2026-08-02.)
+> activated. Clusters A, B and F are closed; C and E are reduced. The register went from
+> **15 open concerns to 9**. Three were opened during the epic rather than closed:
+> **C-33** (config validation cannot be strict while pipeline-core passes its whole
+> combined model config through — found by cross-repo inspection), **C-34** (nothing
+> verifies ADR claims against code — found by review-base-docs), and **C-28** which
+> remains in reduced form because its inert `low_bin`/`high_bin` params were kept as
+> documented reserved placeholders rather than deleted, a maintainer decision.
 
 ---
 
@@ -34,7 +36,7 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Tier:** 3 (Medium)
 - **Description:** `native_metric_calculators.py` imports `sklearn.metrics` and `scipy.stats` at module level. Only 4 metric functions use these (AP, EMD, Pearson, MTD). This contradicts the zero-external-dep goal for Level 0 (ADR-011).
 - **Trigger:** When someone packages views-evaluation as a minimal-dep wheel, or adds a CI/import-lint check asserting Level-0 imports only numpy — the module-level `sklearn`/`scipy` imports fail it.
-- **Location:** `views_evaluation/evaluation/native_metric_calculators.py:2-6` (module-level `sklearn.metrics` and `scipy.stats` imports); used by `calculate_ap_native:76`, `calculate_emd_native:83`, `calculate_pearson_native:88`, `calculate_mtd_native:96`
+- **Location:** `views_evaluation/evaluation/native_metric_calculators.py` — the module-level `sklearn.metrics` and `scipy.stats` imports at the top of the file; consumed by `calculate_ap_native`, `calculate_emd_native`, `calculate_pearson_native` and `calculate_mtd_native`
 - **Source:** repo-assimilation (2026-03-31); trigger sharpened 2026-06-26 (strategic review); Location field added 2026-08-02 (strategic review — required field was missing)
 - **Mitigation path:** Replace with pure-numpy implementations or move affected metrics to a Level 1 module.
 - **Note:** The packaging half (C-19 — `scipy` undeclared in `pyproject.toml`) was **closed on 2026-08-02** (#29). What remains here is purely the ADR-011 purity violation: the imports are now honestly declared, but they still sit in the Level-0 core. Part of causal cluster C.
@@ -45,7 +47,7 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Tier:** 3 (Medium) — reduced from 2 on 2026-08-02; the silent-truncation half was fixed, leaving only the unenforced-convention half
 - **Description:** The step-wise schema groups rows by the caller-supplied `step` identifier under the convention that step = 1-indexed positional lead time (step 1 = the first month of each origin's forecast window). ADR-040 documents the convention and `CICs/EvaluationFrame.md` §8 explains its consequence, but **nothing validates it**. The adapter that used to synthesise `step` positionally (`PandasAdapter`) was deleted in Phase 3, so the assumption now rests entirely on callers. If a caller supplies `step` meaning something else — an absolute month offset, a 0-indexed position — the step groups are mislabelled and cross-model comparison is invalid, with no signal.
 - **Trigger:** When a new consumer (or a rewritten pipeline-core adapter) constructs an `EvaluationFrame` and populates `step` from something other than the 1-indexed position within an origin sequence — e.g. reusing a calendar offset — the step-wise report is silently mislabelled.
-- **Location:** `views_evaluation/evaluation/native_evaluator.py:102-128` (grouping); `documentation/ADRs/040_evaluation_input_schema.md` (the documented convention); `documentation/CICs/EvaluationFrame.md` §8
+- **Location:** `views_evaluation/evaluation/native_evaluator.py` — the step-wise grouping block in `evaluate()`; `documentation/ADRs/040_evaluation_input_schema.md` (the documented convention); `documentation/CICs/EvaluationFrame.md` §8
 - **Source:** repo-assimilation (2026-06-24); scope reduced 2026-08-02 after #37 closed the truncation half
 - **Mitigation path:** This is a **cross-repo contract decision**, not a local fix — the producer of `step` lives in views-pipeline-core. Options: validate at the `EvaluationFrame` boundary that each origin's steps form a contiguous 1..n run; or record the convention as an explicit disagreement entry (D-xx) and accept it. Coordinate with pipeline-core before choosing.
 - **Note:** The **silent-truncation half of this entry was resolved on 2026-08-02** (#37, ADR-015 ruling 7): `legacy_compatibility=True` now raises if truncation would drop a step that `config['steps']` explicitly requested, instead of returning it as an empty placeholder dict. Only the semantics half above remains open. This entry is no longer part of causal cluster A.
@@ -70,7 +72,7 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Location:** `views_evaluation/evaluation/metric_frame.py`; `views_evaluation/evaluation/evaluation_report.py` (`to_metric_frame`)
 - **Source:** review-rr strategic (2026-06-26), blind-spot analysis
 - **Mitigation path:** Extend the drift-guard test to cover axes / `MEAN_GROUP_ID` / `eval_type` vocabulary / a serialization round-trip; pin the persistence convention jointly with pipeline-core + reporting. (**`schema_version` enforcement at load is owned by C-26(b), not here** — de-duplicated 2026-08-02, as both entries previously claimed the same fix.) See views-reporting C-41 (token drift, consumer side) and C-26 (serialization fidelity).
-- **Note:** Part of causal cluster D (MetricFrame evaluation-of-record). This repo's most consequential cross-repo surface — consumers are actively coding against it.
+- **Note:** Part of causal cluster D (MetricFrame evaluation-of-record). This repo's most consequential cross-repo surface — consumers are actively coding against it. **Governance asymmetry (added 2026-08-02):** this repo *owns* the artifact but its governing decision record is views-frames **ADR-020**, in another repo. Locally, ADR-041 was the nearest thing to an output contract and it asserted the opposite of what the code does (that views-evaluation never persists to disk) until corrected on 2026-08-02, and `MetricFrame` had no Intent Contract until the same date. A contract with no local authoritative statement is easier to drift from — which is the exposure this entry tracks. See also C-34.
 
 ---
 
@@ -111,10 +113,21 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Tier:** 3 (Medium) — no correctness impact today, but it caps what this repo can validate and it nearly caused a platform-wide outage
 - **Description:** `views-pipeline-core` calls `NativeEvaluator(context.configs)` (`views_pipeline_core/managers/evaluation/stage.py:122`), where `context.configs` is `_config_manager.get_combined_config()` — the **whole merged model config**: meta, hyperparameters, deployment, partitions, queryset and sweep. A real config (views-models `ravaging_thief`) therefore arrives carrying `name`, `algorithm`, `level`, `creator`, `batch_size`, `n_epochs`, `input_chunk_length`, `regression_point_baselines` and ~10 more keys that this library knows nothing about. The intended design was **separate per-concern configs**, with evaluation owning its own; they were merged into one during earlier development and have not been separated since. The maintainer's position (2026-08-02) is that this will be fixed, but not now.
 - **Trigger:** When someone adds validation to `NativeEvaluator` that assumes the incoming dict is evaluation-specific. On 2026-08-02 a blanket "reject unrecognised keys" check was written on exactly that assumption and would have **broken every model in the platform** — 17 rejected keys on a single real config, raising at construction before any evaluation ran, and through pipeline-core blocking the ~45 repos downstream of its 3.0.0 release. It was caught by reading pipeline-core before merging, not by any test.
-- **Location:** `views_evaluation/evaluation/native_evaluator.py` (`_validate_config`, step 1b and its comment); `views_pipeline_core/managers/evaluation/stage.py:122`; `views_pipeline_core/managers/**/get_combined_config`
+- **Location:** `views_evaluation/evaluation/native_evaluator.py` (`_validate_config`, step 1b and its comment); `views_pipeline_core/managers/evaluation/stage.py` (the `NativeEvaluator(context.configs)` call site); `views_pipeline_core/managers/configuration/configuration.py` (`get_combined_config`)
 - **Source:** cross-repo inspection during epic #26 (2026-08-02), after the blanket check was found to break pipeline-core
 - **Mitigation path:** Upstream — split the combined config so evaluation receives only its own section, then this repo can validate strictly. Until then `NativeEvaluator` must **tolerate unrecognised keys**, and can only flag keys that closely resemble a real evaluation key (a typo), never reject wholesale.
 - **Note:** ⚠ **Do not "tighten" `_validate_config` to reject unknown keys** without fixing the config split first. `tests/test_native_evaluator.py::TestCombinedConfigTolerance` pins a real combined config as a regression guard; if that test fails, every model in the platform is broken. Related to C-02 (the validation this constrains).
+
+---
+
+### C-34 — Nothing verifies that an ADR's claims still match the code
+- **Tier:** 3 (Medium)
+- **Description:** The repo has two automated documentation guards, and **neither checks whether an ADR's assertions about the system are still true**. `documentation/validate_docs.sh` checks structural integrity only (unfilled placeholders, CIC references resolve, protocol files exist) and its cross-ADR check is scoped to the constitutional band `000-009`. `tests/test_documentation_contracts.py` checks specific, hand-picked code facts (documented defaults, required identifiers, genome consumption, metric-token currency) — a deliberately narrow set, not general claim verification. The consequence, found by review-base-docs on 2026-08-02: the entire **04x "Data & Integration Contracts" band had drifted from reality**, undetected, for four months. **ADR-031** listed Brier Score as unimplemented (three variants shipped 2026-04-09) while omitting `pEMDiv` (genuinely unimplemented) — wrong in both directions. **ADR-041** asserted that "views-evaluation returns a structured dictionary, and views-pipeline-core handles the persistence to disk", which `MetricFrame.save()` had directly falsified. **ADR-040** declared the native path the "sole integration path" and then specified a Pandas `MultiIndex` input format the library can no longer accept. All three were Accepted-or-Proposed governance documents describing an architecture that no longer existed.
+- **Trigger:** When a new consumer repo integrates against views-evaluation and uses the 04x ADRs as the specification — as they are meant to — it will build against an architecture that may no longer exist. Equally: when any ADR's Decision section is contradicted by a later code change, nothing fails, so the divergence is only ever found by a manual audit that happens to look.
+- **Location:** `documentation/validate_docs.sh` (structural checks only; cross-ADR check limited to `00[0-9]`); `tests/test_documentation_contracts.py` (narrow, enumerated checks); the 04x ADR band (`040`, `041`, `031`)
+- **Source:** review-base-docs (2026-08-02) — the audit that found the drift is itself the evidence that only a manual audit finds it
+- **Mitigation path:** The individual drifts found on 2026-08-02 were corrected the same day, so this entry is about the **detection gap, not those instances**. Options: extend `test_documentation_contracts.py` with a check per falsifiable ADR claim (cheap per claim, but only covers claims someone thought to encode); require each ADR to carry a machine-checkable "Validation" assertion; or accept that ADRs need periodic `review-base-docs` passes and schedule them. The 00x–02x constitutional band did **not** drift, which suggests the risk concentrates in ADRs describing integration surfaces that change, not principles that do not.
+- **Note:** Distinct from C-24, which is about the *cross-repo emit contract* drifting between repos. This is about *this repo's own ADRs* drifting from *this repo's own code*. See also C-29 (closed) — the README made a false behavioural promise for four months for the same underlying reason, and the fix there was a targeted test, which is the pattern this entry generalises.
 
 ---
 
@@ -156,7 +169,7 @@ Moved out of the register (no correctness/reliability dimension) — tracked in 
 | C-02 | **1** | NativeEvaluator does not validate config at init | `_validate_config()` added to `__init__`: rejects unknown/misspelled keys (valid set derived from `EvaluationConfig.__annotations__`), missing/empty/non-positive `steps`, absent target lists, declared tasks with no metrics, and invalid metric names. A resolved `(task, pred_type)` with no metrics now raises at `evaluate()` — the one case that cannot be known at construction. 10 Red tests. | #31 |
 | C-13 | 2 | No deprecation protocol for public API symbols | **ADR-022 activated** (was `Proposed (Deferred)`; its own trigger "breaking changes incur high coordination costs" had fired). Defines the public API surface, a one-release-cycle deprecation contract, the `DeprecationWarning`-vs-fail-loud boundary, `0.x` versioning, a retroactive position on the 0.4.0 removals, and a release checklist as the enforcement point. | #28 |
 | C-19 | 3 | `scipy` is an undeclared runtime dependency | Declared `scipy = "^1.11"` in `pyproject.toml`. It was a load-time import satisfied only transitively via scikit-learn. | #29 |
-| C-27 | 2 | `Ignorance` crashes on observations above the top bin edge | Both tails guarded and raise with a message naming the value and the configured range. Previously `IndexError` above (masked when a prediction was also out of range) and a wrong-bin score below. | #32 |
+| C-27 | 2 | `Ignorance` crashes on observations above the top bin edge | Both tails guarded and raise with a message naming the value and the configured range. Previously `IndexError` above (masked when a prediction was also out of range) and a wrong-bin score below. ⚠ **Severity note (corrected 2026-08-02):** the entry claimed this was "on the production path" because `Ignorance` is in views-reporting's canonical metric set. A full audit of all 130 views-models configs found **no model requests `Ignorance` at all**, so the crash was latent, not live. The fix stands; the urgency claim was overstated. Note the converse mismatch: views-reporting's canonical set (`views_reporting/config/_reporting.py:48`) DOES list `Ignorance`, so that slot renders "not calculated" permanently — a cross-repo gap, not tracked here. | #32 |
 | C-29 | 3 | README promises a `DeprecationWarning` no code implements | README corrected: legacy keys were removed in 0.4.0 and now raise at `__init__` as unknown keys. The shim was **not** restored — it had been absent from the published package since 2026-05-18. Guarded against recurrence by `tests/test_documentation_contracts.py`. | #38, #40 |
 | C-30 | 3 | `to_metric_frame()` emits a valid zero-row evaluation-of-record | Emit now raises when no schema has any metric value, naming the target and which schemas were present-but-empty, and logging at `ERROR` first (Level-1 emit path). `MetricFrame` itself still accepts zero rows so `load()` can read back whatever `save()` wrote. | #34 |
 | C-31 | 4 | `EvaluationFrame` does not validate `y_true.ndim` | `y_true.ndim != 1` now raises at construction, placed after the dtype gate so a non-numeric array is still reported as a dtype problem. | #36 |

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,13 +1,15 @@
 # Technical Risk Register — views-evaluation
 
 **Last updated:** 2026-08-02
-**Total open concerns:** 7
+**Total open concerns:** 8
 **Governing ADR:** ADR-023
 
 > **2026-08-02 — Fail-Loud Doctrine epic (#26) closed 10 concerns.** ADR-015 (Degenerate
 > and Empty Results) was written and applied; ADR-022 (Evolution and Stability) was
 > activated. Clusters A, B and F are closed; C and E are reduced. The
-> register went from 15 open concerns to 7. (C-28 remains open in reduced form: its
+> register went from 15 open concerns to 8 (C-33 was opened during the epic:
+> cross-repo inspection found that config validation cannot be strict while
+> pipeline-core passes its whole combined model config through). (C-28 remains open in reduced form: its
 > inert `low_bin`/`high_bin` params were kept as documented reserved placeholders
 > rather than deleted — a maintainer decision on 2026-08-02.)
 
@@ -102,6 +104,17 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Source:** repo-assimilation (2026-08-02), empirically verified; scope reduced 2026-08-02 after #32 fixed half (a); retained as a placeholder by maintainer decision rather than deleted
 - **Mitigation path:** **Use it or lose it.** Either (1) activate them — which requires supporting integer `bins`, raising on the contradictory `bins`-sequence-plus-range case, validating `low_bin < high_bin`, and making ADR-015 ruling 8's error message cite them rather than the computed edges; or (2) delete them from the genome, every profile, and the kernel signature. The full activation spec is in the kernel docstring's status block.
 - **Note:** Guarded against silent drift in **both** directions by `tests/test_metric_catalog.py::TestIgnoranceReservedPlaceholders` — activating them breaks the inertness test, deleting them breaks the genome test. `CICs/MetricCatalog.md` records the four conditions a reserved placeholder must satisfy to remain one; failing any of them, it is dead configuration and must be deleted.
+
+---
+
+### C-33 — Evaluation config is not separable from the combined model config
+- **Tier:** 3 (Medium) — no correctness impact today, but it caps what this repo can validate and it nearly caused a platform-wide outage
+- **Description:** `views-pipeline-core` calls `NativeEvaluator(context.configs)` (`views_pipeline_core/managers/evaluation/stage.py:122`), where `context.configs` is `_config_manager.get_combined_config()` — the **whole merged model config**: meta, hyperparameters, deployment, partitions, queryset and sweep. A real config (views-models `ravaging_thief`) therefore arrives carrying `name`, `algorithm`, `level`, `creator`, `batch_size`, `n_epochs`, `input_chunk_length`, `regression_point_baselines` and ~10 more keys that this library knows nothing about. The intended design was **separate per-concern configs**, with evaluation owning its own; they were merged into one during earlier development and have not been separated since. The maintainer's position (2026-08-02) is that this will be fixed, but not now.
+- **Trigger:** When someone adds validation to `NativeEvaluator` that assumes the incoming dict is evaluation-specific. On 2026-08-02 a blanket "reject unrecognised keys" check was written on exactly that assumption and would have **broken every model in the platform** — 17 rejected keys on a single real config, raising at construction before any evaluation ran, and through pipeline-core blocking the ~45 repos downstream of its 3.0.0 release. It was caught by reading pipeline-core before merging, not by any test.
+- **Location:** `views_evaluation/evaluation/native_evaluator.py` (`_validate_config`, step 1b and its comment); `views_pipeline_core/managers/evaluation/stage.py:122`; `views_pipeline_core/managers/**/get_combined_config`
+- **Source:** cross-repo inspection during epic #26 (2026-08-02), after the blanket check was found to break pipeline-core
+- **Mitigation path:** Upstream — split the combined config so evaluation receives only its own section, then this repo can validate strictly. Until then `NativeEvaluator` must **tolerate unrecognised keys**, and can only flag keys that closely resemble a real evaluation key (a typo), never reject wholesale.
+- **Note:** ⚠ **Do not "tighten" `_validate_config` to reject unknown keys** without fixing the config split first. `tests/test_native_evaluator.py::TestCombinedConfigTolerance` pins a real combined config as a regression guard; if that test fails, every model in the platform is broken. Related to C-02 (the validation this constrains).
 
 ---
 

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -36,16 +36,17 @@ README = REPO_ROOT / "README.md"
 DOCS = REPO_ROOT / "documentation"
 CICS = DOCS / "CICs"
 
-# File paths deleted in Phase 3. Documentation must not present them as if they exist.
-#
-# Deliberately matched as *paths*, not class names: the drift this guards against is a
-# project-structure tree or file listing citing a module that is gone. Prose that
-# explains why `EvaluationManager` was removed is legitimate and must not trip this.
-_DELETED_MODULE_PATHS = [
-    "evaluation_manager.py",
-    "adapters/pandas.py",
-    "adapters.pandas",
-]
+# Symbols removed in the Phase 3 purge (commit fe6dd4c, 2026-04-01). One structure so
+# that retiring a further symbol means editing one place, not two: the prose check below
+# matches file PATHS (a project-structure tree citing a module that is gone) while the
+# docstring check matches CLASS NAMES (source claiming a deleted class still does work).
+_DELETED_SYMBOLS = (
+    # (class name, module paths that would appear in a file listing)
+    ("EvaluationManager", ("evaluation_manager.py",)),
+    ("PandasAdapter", ("adapters/pandas.py", "adapters.pandas")),
+)
+_DELETED_MODULE_PATHS = [p for _, paths in _DELETED_SYMBOLS for p in paths]
+_DELETED_CLASS_NAMES = [name for name, _ in _DELETED_SYMBOLS]
 
 # Files where a historical mention is legitimate: change logs, decision records and
 # the risk register all necessarily discuss things that no longer exist.
@@ -56,6 +57,50 @@ _HISTORICAL_ALLOWLIST = {
     "documentation/contributor_protocols",
     "reports",                        # register + post-mortems are history by nature
 }
+
+# Prose may legitimately name a removed symbol or a superseded metric when it is
+# *explaining* the removal or rename. These markers signal that framing, matched
+# case-insensitively against the whole block (see `_blocks`), not a single line.
+#
+# ⚠ This couples the checks to prose wording. `config_schema.py`'s note passes the
+# deleted-class check only because it opens "Until 0.4.0 this docstring named ...".
+# If you reword such a note, keep one of these markers somewhere in the same paragraph —
+# or add the new phrasing here — otherwise the check fails for a purely cosmetic edit.
+_HISTORICAL_MARKERS = (
+    "until 0.", "prior to 0.", "before 0.",
+    "was removed", "were removed", "was deleted", "were deleted",
+    "removed in phase 3", "deleted in phase 3",
+    "replaced by", "were replaced", "renamed", "breaking rename",
+    "intentionally omitted", "pre-pr-", "legacy name", "no longer",
+)
+
+
+def _is_historical(text: str) -> bool:
+    """True if the text frames its subject as history rather than as current fact."""
+    lowered = text.lower()
+    return any(marker in lowered for marker in _HISTORICAL_MARKERS)
+
+
+def _blocks(text: str):
+    """Yield (start_lineno, block_text) for each blank-line-separated block.
+
+    Checks operate on blocks, not lines, because prose wraps: in
+    `physical_architecture_standard.md` the phrase "the pre-PR-#18 names" sits on one
+    line and the names it is explaining wrap onto the next. Line-based matching split
+    the framing from its subject and produced a false positive.
+    """
+    lines = text.splitlines()
+    start, buf = 1, []
+    for i, line in enumerate(lines, 1):
+        if line.strip():
+            if not buf:
+                start = i
+            buf.append(line)
+        elif buf:
+            yield start, "\n".join(buf)
+            buf = []
+    if buf:
+        yield start, "\n".join(buf)
 
 
 def _doc_files():
@@ -150,6 +195,67 @@ class TestDocumentationMatchesCode:
                 f"EvaluationFrame enforces identifier '{key}' but "
                 f"NativeEvaluator.md §4 does not list it"
             )
+
+    def test_no_doc_or_docstring_names_a_deleted_class_as_current(self):
+        """Python docstrings were unguarded, and that is how C-02's record went stale.
+
+        `config_schema.py` named `EvaluationManager._validate_config` as the runtime
+        validator for four months after that class was deleted — through a Phase 3
+        purge, a strategic review, and an epic that rewrote the surrounding module.
+        The .md-only checks above could not see it.
+        """
+        import views_evaluation
+        pkg_root = Path(views_evaluation.__file__).parent
+        offenders = []
+        for py in pkg_root.rglob("*.py"):
+            for lineno, block in _blocks(py.read_text()):
+                if _is_historical(block):
+                    continue
+                for name in _DELETED_CLASS_NAMES:
+                    if name in block:
+                        offenders.append(
+                            f"{py.relative_to(pkg_root.parent)}:{lineno} names '{name}'"
+                        )
+        assert not offenders, (
+            "Source docstrings/comments present a deleted class as current:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_documentation_uses_current_metric_names(self):
+        """Metric tokens in prose must exist in METRIC_CATALOG.
+
+        `physical_architecture_standard.md` listed `Brier_point`/`Brier_sample` for four
+        months after PR #18 renamed them — despite a reviewer on that PR explicitly
+        asking for the reference to be updated.
+        """
+        from views_evaluation.evaluation.metric_catalog import METRIC_CATALOG
+
+        # Derive the families to police from the catalog rather than hardcoding them, so
+        # a future underscore-family metric is covered without editing this test. Only
+        # capitalised prefixes qualify: `y_hat_bar` would contribute the prefix "y",
+        # which would match `y_true`/`y_pred` throughout the prose.
+        prefixes = sorted(
+            {m.split("_")[0] for m in METRIC_CATALOG if "_" in m and m[0].isupper()}
+        )
+        pattern = r"\b(?:" + "|".join(prefixes) + r")_\w+"
+
+        # Prose that explains a rename necessarily quotes the old name; _is_historical
+        # allows that framing and flags a token presented as current.
+        offenders = []
+        for path in _doc_files():
+            for lineno, block in _blocks(path.read_text()):
+                if _is_historical(block):
+                    continue
+                for token in set(re.findall(pattern, block)):
+                    if token not in METRIC_CATALOG:
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)}:{lineno} names '{token}'"
+                        )
+        assert not offenders, (
+            "Documentation presents metric tokens absent from METRIC_CATALOG as current:\n  "
+            + "\n  ".join(sorted(offenders))
+            + f"\nValid: {sorted(METRIC_CATALOG)}"
+        )
 
     def test_every_genome_param_is_consumed_by_its_function(self):
         """MetricCatalog's 'genome honesty' invariant.

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -1,0 +1,261 @@
+"""
+Documentation-contract tests: assert that the docs describe the code as it is.
+
+Why this file exists
+--------------------
+The original ``tests/test_documentation_contracts.py`` was deleted in the Phase 3
+purge (commit ``fe6dd4c``, 2026-04-01) along with nine other test files. The others
+were ``PHASE-3-DELETE`` tests for code that genuinely no longer existed (tracked and
+closed as register C-06). This one had **no replacement**, and the consequences were
+measurable:
+
+  * The README promised legacy config keys still worked and emitted a
+    ``DeprecationWarning``. No such code existed — and that claim **shipped in
+    published 0.4.0** (register C-29).
+  * The README listed ``evaluation_manager.py``, deleted four months earlier.
+  * ``CICs/NativeEvaluator.md`` §3 said ``legacy_compatibility`` defaulted to ``True``
+    while §11 and the code said ``False``.
+  * ``CICs/NativeEvaluator.md`` §4 omitted the required ``unit`` identifier.
+
+Every check below is narrow and falsifiable, and each is anchored to one of those
+real regressions. This file must not become a prose or style checker — the original
+was deleted partly because it had drifted into unfalsifiable territory, and a test
+nobody trusts gets deleted again.
+
+Per ADR-020 the checks are Red: they assert that a specific documented claim matches
+a specific code fact, and fail loudly when it stops doing so.
+"""
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+DOCS = REPO_ROOT / "documentation"
+CICS = DOCS / "CICs"
+
+# File paths deleted in Phase 3. Documentation must not present them as if they exist.
+#
+# Deliberately matched as *paths*, not class names: the drift this guards against is a
+# project-structure tree or file listing citing a module that is gone. Prose that
+# explains why `EvaluationManager` was removed is legitimate and must not trip this.
+_DELETED_MODULE_PATHS = [
+    "evaluation_manager.py",
+    "adapters/pandas.py",
+    "adapters.pandas",
+]
+
+# Files where a historical mention is legitimate: change logs, decision records and
+# the risk register all necessarily discuss things that no longer exist.
+_HISTORICAL_ALLOWLIST = {
+    "documentation/ADRs",             # ADRs record why things were removed
+    "documentation/CICs/EvaluationReport.md",   # Evolution Notes
+    "documentation/CICs/NativeEvaluator.md",    # Evolution Notes
+    "documentation/contributor_protocols",
+    "reports",                        # register + post-mortems are history by nature
+}
+
+
+def _doc_files():
+    """All documentation prose, excluding files whose job is to record history."""
+    files = [README]
+    for path in DOCS.rglob("*.md"):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(rel.startswith(prefix) for prefix in _HISTORICAL_ALLOWLIST):
+            continue
+        files.append(path)
+    return files
+
+
+class TestDocumentationMatchesCode:
+
+    def test_no_doc_lists_a_deleted_module_path(self):
+        """Guards the README-structure-tree-listing-evaluation_manager.py drift."""
+        offenders = []
+        for path in _doc_files():
+            text = path.read_text()
+            for name in _DELETED_MODULE_PATHS:
+                if name in text:
+                    offenders.append(f"{path.relative_to(REPO_ROOT)} lists '{name}'")
+        assert not offenders, (
+            "Documentation lists module paths deleted in Phase 3:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_readme_makes_no_legacy_config_key_support_claim(self):
+        """The exact C-29 regression guard.
+
+        Published 0.4.0's README told users legacy keys still worked and warned. The
+        shim had already been deleted, so those keys silently produced empty reports.
+
+        Matched on the present-tense support claim: prose *explaining* that the old
+        documentation was wrong necessarily quotes it, and must not trip this.
+        """
+        text = README.read_text()
+        claim = re.compile(
+            r"[Ll]egacy keys still work\b(?!ed)",   # "still work"/"still works", not "still worked"
+        )
+        assert not claim.search(text), (
+            "README claims legacy config keys still work. They were removed in 0.4.0 "
+            "and now raise at NativeEvaluator.__init__ (register C-29)."
+        )
+
+    def test_readme_states_legacy_keys_were_removed(self):
+        """The positive half: silence is not enough, the README must say what happened."""
+        text = README.read_text()
+        assert re.search(r"[Ll]egacy keys were REMOVED|removed in 0\.4\.0", text), (
+            "README must state explicitly that legacy config keys were removed in "
+            "0.4.0, so a migrating user is not left guessing."
+        )
+
+    def test_legacy_compatibility_default_matches_the_code(self):
+        """CIC §3 contradicted §11 and the code on this exact flag."""
+        from views_evaluation.evaluation.native_evaluator import NativeEvaluator
+
+        actual = inspect.signature(NativeEvaluator.evaluate).parameters[
+            "legacy_compatibility"
+        ].default
+        cic = (CICS / "NativeEvaluator.md").read_text()
+
+        documented = re.search(
+            r"legacy_compatibility`? flag \(\*\*?default `(True|False)`",
+            cic,
+        )
+        assert documented, (
+            "NativeEvaluator.md no longer states the legacy_compatibility default; "
+            "it must, because the contract previously contradicted the code on it."
+        )
+        assert (documented.group(1) == "True") is (actual is True), (
+            f"CIC documents legacy_compatibility default as {documented.group(1)} "
+            f"but the code default is {actual}"
+        )
+
+    def test_documented_required_identifiers_match_the_code(self):
+        """CIC §4 omitted 'unit', which _validate has always required."""
+        from views_evaluation.evaluation import evaluation_frame
+
+        src = inspect.getsource(evaluation_frame)
+        match = re.search(r"required_keys\s*=\s*\{([^}]*)\}", src)
+        assert match, "could not locate required_keys in EvaluationFrame._validate"
+        enforced = set(re.findall(r"'(\w+)'", match.group(1)))
+
+        cic = (CICS / "NativeEvaluator.md").read_text()
+        identifier_line = next(
+            (ln for ln in cic.splitlines() if "Identifier Presence" in ln), ""
+        )
+        for key in enforced:
+            assert f"`{key}`" in identifier_line, (
+                f"EvaluationFrame enforces identifier '{key}' but "
+                f"NativeEvaluator.md §4 does not list it"
+            )
+
+    def test_every_genome_param_is_consumed_by_its_function(self):
+        """MetricCatalog's 'genome honesty' invariant.
+
+        Its absence let Ignorance declare low_bin/high_bin — parameters NumPy silently
+        ignores whenever bins is a sequence, so they were required configuration that
+        changed nothing (register C-28b).
+        """
+        from views_evaluation.evaluation.metric_catalog import METRIC_CATALOG
+
+        offenders = []
+        for name, spec in METRIC_CATALOG.items():
+            if not spec.genome:
+                continue
+            params = inspect.signature(spec.function).parameters
+            if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+                declared = {
+                    p for p, v in params.items()
+                    if v.kind is inspect.Parameter.KEYWORD_ONLY
+                }
+            else:
+                declared = set(params)
+            missing = set(spec.genome) - declared
+            if missing:
+                offenders.append(f"{name}: declares {sorted(missing)}, not a parameter")
+        assert not offenders, (
+            "Genome parameters not consumed by their metric function:\n  "
+            + "\n  ".join(offenders)
+        )
+
+
+class TestIntentContractRegistry:
+    """ADR-021: the Active Contracts list and the CIC files must agree, both ways."""
+
+    def _listed(self):
+        readme = (CICS / "README.md").read_text()
+        return set(re.findall(r"^- `([A-Z]\w*\.md)`", readme, re.MULTILINE))
+
+    def _on_disk(self):
+        return {
+            p.name for p in CICS.glob("*.md")
+            if p.name not in {"README.md", "cic_template.md"}
+        }
+
+    def test_every_listed_contract_exists(self):
+        missing = self._listed() - self._on_disk()
+        assert not missing, f"CICs/README.md lists non-existent contracts: {sorted(missing)}"
+
+    def test_every_contract_is_listed(self):
+        unlisted = self._on_disk() - self._listed()
+        assert not unlisted, (
+            f"Intent Contracts exist but are absent from the Active Contracts list "
+            f"in CICs/README.md: {sorted(unlisted)}"
+        )
+
+
+class TestAdrRegistry:
+
+    def test_every_adr_file_is_indexed(self):
+        """A new ADR that nobody can find from the index is effectively invisible."""
+        adr_dir = DOCS / "ADRs"
+        readme = (adr_dir / "README.md").read_text()
+        on_disk = {
+            p.name for p in adr_dir.glob("*.md")
+            if p.name not in {"README.md", "adr_template.md"}
+        }
+        missing = {name for name in on_disk if name not in readme}
+        assert not missing, (
+            f"ADRs exist but are not indexed in ADRs/README.md: {sorted(missing)}"
+        )
+
+    @pytest.mark.parametrize("adr", ["015_degenerate_and_empty_results.md",
+                                     "022_evolution_and_stability.md"])
+    def test_governing_adrs_are_accepted(self, adr):
+        """These two govern behaviour asserted elsewhere in the suite."""
+        text = (DOCS / "ADRs" / adr).read_text()
+        assert re.search(r"^\*\*Status:\*\*\s*Accepted", text, re.MULTILINE), (
+            f"{adr} is not in Accepted status, but code depends on its rulings"
+        )
+
+
+class TestLoggingScopeContract:
+    """The Level-0/Level-1 split from logging standard §5.1, asserted against code."""
+
+    _LEVEL_0 = [
+        "evaluation_frame", "native_evaluator", "evaluation_report",
+        "metric_catalog", "native_metric_calculators",
+    ]
+
+    @pytest.mark.parametrize("module_name", _LEVEL_0)
+    def test_level_zero_modules_declare_no_module_logger(self, module_name):
+        import importlib
+        module = importlib.import_module(f"views_evaluation.evaluation.{module_name}")
+        src = inspect.getsource(module)
+        # A module-level `logger = logging.getLogger(__name__)` is the violation.
+        assert not re.search(r"^logger\s*=\s*logging\.getLogger", src, re.MULTILINE), (
+            f"{module_name} is Level 0 and must not maintain a module logger "
+            f"(logging standard §5.1)"
+        )
+
+    def test_standard_names_both_levels_explicitly(self):
+        """The old scope note named three classes and predated metric_frame.py,
+        leaving Level 1 uncovered by omission. It must now be explicit."""
+        text = (DOCS / "standards" / "logging_and_observability_standard.md").read_text()
+        assert "metric_frame.py" in text, (
+            "logging standard §5.1 must name metric_frame.py explicitly, so the "
+            "Level-1 gap cannot silently reopen"
+        )
+        assert "Level 1" in text and "Level 0" in text

--- a/tests/test_evaluation_frame.py
+++ b/tests/test_evaluation_frame.py
@@ -214,6 +214,36 @@ class TestEvaluationFrameBeige:
 
 class TestEvaluationFrameRed:
 
+    def test_two_dimensional_y_true_raises(self):
+        """C-31: the symmetric partner of the y_pred.ndim check (C-03).
+
+        An un-squeezed (N, 1) column — a common shape out of a DataFrame column or a
+        model head — previously constructed fine and reported a plausible n_rows,
+        failing much later as a *metric* error instead of an input-contract one.
+        """
+        with pytest.raises(ValueError, match="y_true must be 1D"):
+            EvaluationFrame(
+                y_true=np.zeros((4, 2)),
+                y_pred=np.zeros((4, 3)),
+                identifiers={
+                    'time': np.arange(4), 'unit': np.arange(4),
+                    'origin': np.zeros(4, dtype=int), 'step': np.ones(4, dtype=int),
+                },
+            )
+
+    def test_column_vector_y_true_raises(self):
+        """The realistic shape: (N, 1) rather than (N,)."""
+        with pytest.raises(ValueError, match="y_true must be 1D"):
+            EvaluationFrame(
+                y_true=np.zeros((4, 1)),
+                y_pred=np.zeros((4, 3)),
+                identifiers={
+                    'time': np.arange(4), 'unit': np.arange(4),
+                    'origin': np.zeros(4, dtype=int), 'step': np.ones(4, dtype=int),
+                },
+            )
+
+
     def test_object_dtype_y_true_raises(self):
         """Object-dtype y_true must be rejected — Pure NumPy contract (ADR-011)."""
         n = 2

--- a/tests/test_metric_calculators.py
+++ b/tests/test_metric_calculators.py
@@ -1088,3 +1088,165 @@ class TestExtremeValues:
         y_pred = np.array([[base - 1e-30, base + 1e-30]])
         result = calculate_coverage_native(y_true, y_pred, alpha=0.1)
         assert np.isfinite(result)
+
+
+# ---------------------------------------------------------------------------
+# Ignorance bin-range contract (ADR-015 ruling 8; risk register C-27, C-28a)
+#
+# RED   — observations outside the configured bins must raise, at BOTH tails.
+# BEIGE — boundary behaviour at the edges themselves, pinned rather than incidental.
+# ---------------------------------------------------------------------------
+
+class TestIgnoranceBinRangeRed:
+
+    def _profile(self):
+        from views_evaluation.profiles.base import BASE_PROFILE
+        return BASE_PROFILE["Ignorance"]
+
+    def test_observation_above_top_edge_raises(self):
+        """C-27: previously an IndexError on ordinary country-month fatality counts.
+
+        BASE_PROFILE's top bin edge is 1000.5; monthly country-level counts exceed
+        that routinely, so this was on the production path, not a corner case.
+        """
+        y_true = np.array([2000.0])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        with pytest.raises(ValueError, match="outside the configured bin range"):
+            calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+
+    def test_observation_below_bottom_edge_raises(self):
+        """C-28a: previously negative-indexed into the LAST bin and returned 3.7004."""
+        y_true = np.array([-1.0])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        with pytest.raises(ValueError, match="outside the configured bin range"):
+            calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+
+    def test_above_range_raises_even_when_a_prediction_is_also_out_of_range(self):
+        """The old crash was masked when a prediction also exceeded the range.
+
+        bincount(minlength=n_bins) grew the array, making the out-of-bounds index
+        accidentally valid. The observation is still outside the configured bins,
+        so it must raise either way.
+        """
+        y_true = np.array([2000.0])
+        y_pred = np.array([[1.0, 2.0, 5000.0]])
+        with pytest.raises(ValueError, match="outside the configured bin range"):
+            calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+
+    def test_error_message_names_value_and_range(self):
+        y_true = np.array([2000.0])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        with pytest.raises(ValueError) as excinfo:
+            calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+        msg = str(excinfo.value)
+        assert "2000.0" in msg, "message must name the offending observation"
+        assert "1000.5" in msg, "message must name the configured range"
+        assert "bins" in msg, "message must tell the caller what to change"
+
+
+class TestIgnoranceBinRangeBeige:
+
+    def _profile(self):
+        from views_evaluation.profiles.base import BASE_PROFILE
+        return BASE_PROFILE["Ignorance"]
+
+    def test_observation_on_bottom_edge_is_in_range(self):
+        """Bins are half-open [lo, hi): the bottom edge belongs to the first bin."""
+        y_true = np.array([0.0])
+        y_pred = np.array([[0.0, 1.0, 2.0]])
+        result = calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+        assert np.isfinite(result)
+
+    def test_observation_on_top_edge_raises(self):
+        """Half-open range: the top edge is in no bin, so it is out of range."""
+        y_true = np.array([1000.5])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        with pytest.raises(ValueError, match="outside the configured bin range"):
+            calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+
+    def test_in_range_value_is_unchanged_by_the_guard(self):
+        """The guard must not alter any previously-correct result."""
+        y_true = np.array([3.0])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        result = calculate_ignorance_score_native(y_true, y_pred, **self._profile())
+        assert np.isfinite(result) and result > 0
+
+
+# ---------------------------------------------------------------------------
+# Pearson constant-input contract (ADR-015 ruling 2; risk register C-22)
+#
+# Contrast with MCR (TestMCR*), whose inf/nan IS retained as a documented sentinel:
+# MCR's inf is a real answer ("predicted conflict where none occurred"); Pearson's
+# nan is the absence of one. That asymmetry is the whole of ADR-015's exception test.
+# ---------------------------------------------------------------------------
+
+class TestPearsonConstantInputBeige:
+    """`Pearson` returns NaN on constant input — a documented sentinel (ADR-015 R2).
+
+    Same category as MCR's inf/nan: a constant series is a property of the data, not a
+    broken invariant. These asserted a raise for one day; the ruling was reversed when
+    it emerged that it aborted any evaluation of a constant baseline (ADR-041 workflow).
+    """
+
+    def test_constant_y_true_returns_nan(self):
+        y_true = np.array([1.0, 1.0, 1.0])
+        y_pred = np.array([[1.0], [2.0], [3.0]])
+        assert np.isnan(calculate_pearson_native(y_true, y_pred))
+
+    def test_constant_y_pred_returns_nan(self):
+        """The baseline-model case: constant predictions, varied truth."""
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([[5.0], [5.0], [5.0]])
+        assert np.isnan(calculate_pearson_native(y_true, y_pred))
+
+    def test_no_constant_input_warning_escapes(self):
+        """The case is contracted and handled, so SciPy's warning is noise.
+
+        A ConstantInputWarning reaching the runner would mean the degenerate case is
+        being encountered rather than handled (ADR-015, Validation & Monitoring).
+        """
+        import warnings as _w
+        y_true = np.array([1.0, 1.0, 1.0])
+        y_pred = np.array([[1.0], [2.0], [3.0]])
+        with _w.catch_warnings():
+            _w.simplefilter("error")      # any escaping warning becomes an exception
+            assert np.isnan(calculate_pearson_native(y_true, y_pred))
+
+
+class TestPearsonGreen:
+
+    def test_non_constant_input_is_unchanged(self):
+        """Perfect positive correlation still returns 1.0 — the guard changes nothing."""
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([[1.0], [2.0], [3.0]])
+        assert calculate_pearson_native(y_true, y_pred) == pytest.approx(1.0)
+
+    def test_perfect_negative_correlation(self):
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([[3.0], [2.0], [1.0]])
+        assert calculate_pearson_native(y_true, y_pred) == pytest.approx(-1.0)
+
+
+class TestMeanPredictionShapeGuardRed:
+    """C-32: y_hat_bar must guard like every sibling kernel, not succeed silently."""
+
+    def test_row_mismatch_raises(self):
+        from views_evaluation.evaluation.native_metric_calculators import (
+            calculate_mean_prediction_native,
+        )
+        with pytest.raises(ValueError, match="Row mismatch"):
+            calculate_mean_prediction_native(np.zeros(4), np.zeros((7, 3)))
+
+    def test_two_dimensional_y_true_raises(self):
+        from views_evaluation.evaluation.native_metric_calculators import (
+            calculate_mean_prediction_native,
+        )
+        with pytest.raises(ValueError, match="y_true must be 1D"):
+            calculate_mean_prediction_native(np.zeros((4, 2)), np.zeros((4, 3)))
+
+    def test_valid_input_value_is_unchanged(self):
+        from views_evaluation.evaluation.native_metric_calculators import (
+            calculate_mean_prediction_native,
+        )
+        y_pred = np.array([[1.0, 2.0], [3.0, 4.0]])
+        assert calculate_mean_prediction_native(np.zeros(2), y_pred) == pytest.approx(2.5)

--- a/tests/test_metric_catalog.py
+++ b/tests/test_metric_catalog.py
@@ -59,6 +59,51 @@ class TestResolveMetricParamsGreen:
         assert result["low_bin"] == 0
         assert result["high_bin"] == 10000
 
+
+class TestIgnoranceReservedPlaceholders:
+    """`low_bin`/`high_bin` are RESERVED PLACEHOLDERS with no effect (C-28b).
+
+    Retained deliberately for planned work. These tests pin the *current* status so it
+    cannot drift silently in either direction: if someone activates them, the inertness
+    test fails and forces the conformance spec to be met; if someone deletes them, the
+    genome test fails and forces the decision to be recorded.
+
+    Activation spec: see the status block in ``calculate_ignorance_score_native``.
+    """
+
+    def test_placeholders_are_still_declared_in_the_genome(self):
+        """Deleting them is a decision, not a tidy-up — it must break a test first."""
+        assert METRIC_CATALOG["Ignorance"].genome == ("bins", "low_bin", "high_bin")
+
+    def test_placeholders_are_still_required_by_the_resolver(self):
+        """They are inert, but not optional — a profile omitting them still fails loud."""
+        profile = {"Ignorance": {"bins": [0, 1, 2]}}
+        with pytest.raises(ValueError, match="requires parameter"):
+            resolve_metric_params("Ignorance", {}, profile)
+
+    def test_placeholders_currently_have_no_effect_on_the_result(self):
+        """The inertness itself, pinned.
+
+        If this test ever fails, `low_bin`/`high_bin` have become live — at which point
+        the conformance spec in the kernel docstring applies, and this test should be
+        replaced by one asserting what they actually do.
+        """
+        from views_evaluation.evaluation.native_metric_calculators import (
+            calculate_ignorance_score_native,
+        )
+        y_true = np.array([3.0])
+        y_pred = np.array([[1.0, 2.0, 3.0]])
+        bins = [0, 0.5, 2.5, 5.5, 10.5]
+        wide = calculate_ignorance_score_native(y_true, y_pred, bins=bins,
+                                                low_bin=0, high_bin=10000)
+        narrow = calculate_ignorance_score_native(y_true, y_pred, bins=bins,
+                                                  low_bin=0, high_bin=1)
+        assert wide == narrow, (
+            "low_bin/high_bin changed the result — they are no longer inert. Meet the "
+            "conformance spec in calculate_ignorance_score_native's docstring and "
+            "replace this test."
+        )
+
     def test_coverage_resolves_from_profile(self):
         """Coverage alpha resolves from base profile."""
         result = resolve_metric_params("Coverage", {}, BASE_PROFILE)

--- a/tests/test_metric_frame.py
+++ b/tests/test_metric_frame.py
@@ -10,6 +10,7 @@ Structured per ADR-020 (Red/Beige/Green):
 The whole module requires the optional 'views-frames' dependency; it is skipped otherwise.
 """
 import json
+import logging
 import tempfile
 
 import numpy as np
@@ -269,14 +270,29 @@ class TestToMetricFrameBeige:
         assert set(mf.identifiers['partition'].tolist()) == {""}
         assert set(mf.identifiers['level'].tolist()) == {""}
 
-    def test_fully_empty_report_yields_zero_row_frame(self):
+    def test_fully_empty_report_raises_rather_than_emitting_zero_rows(self):
+        """Superseded behaviour: this used to assert a valid zero-row frame was emitted.
+
+        ADR-015 ruling 6 forbids it — such a frame passes every envelope check and
+        persists as a legitimate-looking audit artifact recording nothing (C-30).
+        The *container* may still hold zero rows, so that load() can read back
+        whatever save() wrote; that half is asserted in
+        ``TestVacuousEmitRed.test_metricframe_itself_still_accepts_zero_rows``
+        and in ``test_zero_row_container_still_conforms`` below.
+        """
         report = EvaluationReport('t', 'regression', 'point',
                                   {'month': {}, 'time_series': {}, 'step': {}})
-        mf = report.to_metric_frame()
+        with pytest.raises(ValueError, match="produced no rows"):
+            report.to_metric_frame()
+
+    def test_zero_row_container_still_conforms(self):
+        """A directly-constructed empty frame still satisfies the views-frames envelope."""
+        ids = {axis: np.asarray([], dtype=str) for axis in AXES}
+        mf = MetricFrame(np.zeros((0, 1), dtype=np.float32), ids)
         assert mf.n_rows == 0
         assert mf.values.shape == (0, 1)
         assert mf.values.dtype == np.float32
-        assert_frame_envelope(mf)  # empty frame still conforms + round-trips
+        assert_frame_envelope(mf)  # empty container still conforms + round-trips
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +336,78 @@ class TestMetricFrameConstructionRed:
 
 
 # ---------------------------------------------------------------------------
+# RED: Level-1 log-and-raise (ADR-013; logging standard §4, §5.1, §8)
+#
+# MetricFrame is Level 1 — it persists the evaluation-of-record — so its raises
+# must ALSO log at ERROR. Level-0 modules stay exempt and are asserted separately
+# in test_level_zero_modules_have_no_logger.
+# ---------------------------------------------------------------------------
+
+class TestMetricFrameLogAndRaiseRed:
+
+    def _valid_ids(self, n):
+        return {axis: np.asarray(["x"] * n, dtype=str) for axis in AXES}
+
+    def test_non_float32_logs_error_before_raising(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="views_evaluation.evaluation.metric_frame"):
+            with pytest.raises(ValueError, match="float32"):
+                MetricFrame(np.zeros((2, 1), dtype=np.float64), self._valid_ids(2))
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors, "structural failure raised without logging (ADR-013 requires both)"
+        assert "float32" in errors[0].getMessage()
+
+    def test_missing_axis_logs_error_before_raising(self, caplog):
+        ids = self._valid_ids(2)
+        del ids["partition"]
+        with caplog.at_level(logging.ERROR, logger="views_evaluation.evaluation.metric_frame"):
+            with pytest.raises(ValueError, match="missing required axes"):
+                MetricFrame(np.zeros((2, 1), dtype=np.float32), ids)
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors
+        assert "missing required axes" in errors[0].getMessage()
+
+    def test_logged_message_is_identical_to_exception_message(self, caplog):
+        """Standard §4: log and raise carry the same message — not a paraphrase."""
+        ids = self._valid_ids(2)
+        ids["metric"] = np.asarray(["only_one"], dtype=str)
+        with caplog.at_level(logging.ERROR, logger="views_evaluation.evaluation.metric_frame"):
+            with pytest.raises(ValueError) as excinfo:
+                MetricFrame(np.zeros((2, 1), dtype=np.float32), ids)
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors
+        assert errors[0].getMessage() == str(excinfo.value)
+
+    def test_level_zero_modules_have_no_logger(self):
+        """Logging standard §5.1: Level-0 pure-math modules must NOT acquire loggers.
+
+        Guards the exemption in the other direction — a well-meaning contributor
+        adding a logger to the numeric core is a violation, not an improvement.
+        """
+        import inspect
+        from views_evaluation.evaluation import (
+            evaluation_frame,
+            metric_catalog,
+            native_evaluator,
+            native_metric_calculators,
+        )
+        for module in (evaluation_frame, native_evaluator, metric_catalog,
+                       native_metric_calculators):
+            src = inspect.getsource(module)
+            assert "getLogger" not in src, (
+                f"{module.__name__} is Level 0 and must not maintain a logger "
+                f"(logging standard §5.1)"
+            )
+
+    def test_library_never_configures_root_logger(self):
+        """A library must not call basicConfig or attach handlers."""
+        import inspect
+        import views_evaluation.evaluation.metric_frame as mf
+        src = inspect.getsource(mf)
+        assert "basicConfig" not in src
+        assert "addHandler" not in src
+
+
+# ---------------------------------------------------------------------------
 # MetricFrameMetadata direct tests
 # ---------------------------------------------------------------------------
 
@@ -339,3 +427,63 @@ class TestMetricFrameMetadata:
     def test_schema_version_always_present(self):
         meta = MetricFrameMetadata()
         assert meta.to_dict()["schema_version"] == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# RED: vacuous emit (ADR-015 ruling 6; risk register C-30)
+#
+# A zero-row MetricFrame passes _validate AND assert_frame_envelope — dtype,
+# dimensionality and axis alignment are all satisfied. The guard therefore has to
+# live at the emit site, which is also the only place with enough context to say
+# why the report was empty.
+# ---------------------------------------------------------------------------
+
+class TestVacuousEmitRed:
+
+    def test_report_with_no_metric_values_raises(self):
+        report = EvaluationReport('t', 'regression', 'sample',
+                                  {'month': {'month100': {}}, 'time_series': {}, 'step': {}})
+        with pytest.raises(ValueError, match="produced no rows"):
+            report.to_metric_frame(model_id='m')
+
+    def test_completely_empty_report_raises(self):
+        report = EvaluationReport('t', 'regression', 'sample',
+                                  {'month': {}, 'time_series': {}, 'step': {}})
+        with pytest.raises(ValueError, match="produced no rows"):
+            report.to_metric_frame(model_id='m')
+
+    def test_error_message_names_target_and_schemas(self):
+        report = EvaluationReport('ged_sb_best', 'regression', 'sample',
+                                  {'month': {'month100': {}}, 'time_series': {}, 'step': {}})
+        with pytest.raises(ValueError) as excinfo:
+            report.to_metric_frame(model_id='m')
+        msg = str(excinfo.value)
+        assert 'ged_sb_best' in msg
+        assert 'month' in msg
+
+    def test_vacuous_emit_logs_before_raising(self, caplog):
+        """Level-1 emit path logs at ERROR even though the raise sits in a Level-0 file."""
+        report = EvaluationReport('t', 'regression', 'sample',
+                                  {'month': {'month100': {}}, 'time_series': {}, 'step': {}})
+        with caplog.at_level(logging.ERROR, logger="views_evaluation.evaluation.metric_frame"):
+            with pytest.raises(ValueError):
+                report.to_metric_frame(model_id='m')
+        assert [r for r in caplog.records if r.levelname == "ERROR"]
+
+    def test_partial_report_still_emits(self):
+        """A single metric value in a single schema is enough — partial is not vacuous."""
+        report = EvaluationReport('t', 'regression', 'sample',
+                                  {'month': {'month100': {'CRPS': 0.5}},
+                                   'time_series': {}, 'step': {}})
+        mf = report.to_metric_frame(model_id='m')
+        assert mf.n_rows == 2      # the group row + the "mean" aggregate row
+
+    def test_metricframe_itself_still_accepts_zero_rows(self):
+        """The container must stay able to represent whatever load() reads back.
+
+        The guard belongs at emit, not in _validate — tightening the container
+        would break the save/load round-trip and change a cross-repo envelope.
+        """
+        ids = {axis: np.asarray([], dtype=str) for axis in AXES}
+        mf = MetricFrame(np.zeros((0, 1), dtype=np.float32), ids)
+        assert mf.n_rows == 0

--- a/tests/test_native_evaluator.py
+++ b/tests/test_native_evaluator.py
@@ -593,16 +593,41 @@ class TestNativeEvaluatorRed:
             'regression_targets': ['target'],
             'regression_sample_metric': ['CRPS'],   # typo — should be ..._metrics
         }
-        with pytest.raises(ValueError, match="Unknown evaluation config key"):
+        with pytest.raises(ValueError, match="closely resembles"):
+            NativeEvaluator(config)
+
+    def test_typo_is_reported_but_never_substituted(self):
+        """A suspected typo must be named, and then NOT acted on.
+
+        Inferring what the caller meant and proceeding would be exactly the silent
+        repair ADR-015 forbids. The error names the resemblance; the caller fixes it.
+        """
+        config = {'steps': [1], 'regression_targets': ['target'],
+                  'regression_sample_metric': ['CRPS']}
+        with pytest.raises(ValueError) as excinfo:
+            NativeEvaluator(config)
+        msg = str(excinfo.value)
+        assert "regression_sample_metrics" in msg, "must name what it resembles"
+        assert "NOT been interpreted" in msg, "must state that nothing was assumed"
+
+    def test_short_key_typo_rejected_at_init(self):
+        """'step' vs 'steps' — one character, and previously silent."""
+        config = {'step': [1], 'steps': [1], 'regression_targets': ['target'],
+                  'regression_sample_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="closely resembles"):
             NativeEvaluator(config)
 
     def test_legacy_config_keys_rejected_at_init(self):
-        """Legacy keys removed in 0.4.0 now fail loudly instead of silently (C-29)."""
+        """Legacy keys removed in 0.4.0 fail loudly and are NOT translated (C-29).
+
+        Detected by exact name from an enumerated set — not inferred, and never
+        silently mapped to their replacement.
+        """
         for legacy in ('targets', 'metrics',
                        'regression_uncertainty_metrics', 'classification_uncertainty_metrics'):
             config = {'steps': [1], 'regression_targets': ['target'],
                       'regression_point_metrics': ['MSE'], legacy: ['x']}
-            with pytest.raises(ValueError, match="Unknown evaluation config key"):
+            with pytest.raises(ValueError, match="Legacy evaluation config key"):
                 NativeEvaluator(config)
 
     def test_missing_steps_rejected_at_init(self):
@@ -696,3 +721,78 @@ class TestNativeEvaluatorRed:
         }
         with pytest.raises(ValueError, match="not valid"):
             NativeEvaluator(config).evaluate(ef)
+
+
+# ---------------------------------------------------------------------------
+# BEIGE: the combined-config contract with views-pipeline-core
+#
+# pipeline-core calls `NativeEvaluator(context.configs)` where `context.configs` is
+# `_config_manager.get_combined_config()` — the WHOLE merged model config (meta +
+# hyperparameters + deployment + partitions + queryset + sweep). It therefore carries
+# dozens of keys this library knows nothing about, by design.
+#
+# A blanket "reject unrecognised keys" check was written on 2026-08-02 and would have
+# broken every model in the platform: 17 rejected keys on a single real config, at
+# `NativeEvaluator(...)`, before any evaluation ran. It was caught by reading
+# pipeline-core before merging, not by the test suite — hence this file.
+#
+# Register C-33 tracks the underlying config-separation debt.
+# ---------------------------------------------------------------------------
+
+class TestCombinedConfigTolerance:
+
+    def _real_combined_config(self):
+        """A faithful combined config, keys taken verbatim from a real model.
+
+        Source: views-models/models/ravaging_thief/configs/{config_meta,
+        config_hyperparameters}.py — an NHiTS cm-level model.
+        """
+        return {
+            # config_meta.py
+            "name": "ravaging_thief", "algorithm": "NHiTSModel", "level": "cm",
+            "creator": "Dylan", "queryset": "escwa001_cflong",
+            "regression_targets": ["lr_ged_os"],
+            "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline",
+                                           "locf_cmbaseline"],
+            "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
+            "regression_sample_metrics": ["CRPS", "y_hat_bar"],
+            "rolling_origin_stride": 1, "prediction_format": "dataframe",
+            # config_hyperparameters.py
+            "steps": list(range(1, 37)), "input_chunk_length": 36,
+            "output_chunk_length": 36, "output_chunk_shift": 0, "random_state": 67,
+            "time_steps": 36, "num_samples": 1, "mc_dropout": False, "n_jobs": -1,
+            "batch_size": 128, "n_epochs": 300,
+        }
+
+    def test_real_combined_model_config_is_accepted(self):
+        """The regression guard. If this fails, every model in the platform is broken."""
+        NativeEvaluator(self._real_combined_config())      # must not raise
+
+    def test_foreign_keys_are_ignored_not_rejected(self):
+        """Keys that plainly belong to another concern are none of this library's business."""
+        config = {'steps': [1], 'regression_targets': ['t'],
+                  'regression_sample_metrics': ['CRPS'],
+                  'batch_size': 128, 'n_epochs': 300, 'algorithm': 'NHiTSModel',
+                  'wandb_project': 'views', 'sweep_id': 'abc123'}
+        NativeEvaluator(config)                             # must not raise
+
+    def test_baseline_key_is_not_mistaken_for_a_metric_key(self):
+        """`regression_point_baselines` is a REAL pipeline-core key.
+
+        It shares a 17-character prefix with `regression_point_metrics`, so a loose
+        fuzzy matcher would flag it as a typo and break every model that declares
+        baselines. It must be ignored.
+        """
+        config = {'steps': [1], 'regression_targets': ['t'],
+                  'regression_point_metrics': ['MSE'],
+                  'regression_point_baselines': ['zero_cmbaseline'],
+                  'regression_sample_baselines': ['red_ranger']}
+        NativeEvaluator(config)                             # must not raise
+
+    def test_typo_still_caught_inside_a_combined_config(self):
+        """Tolerating foreign keys must not cost us the typo protection."""
+        config = self._real_combined_config()
+        del config['regression_sample_metrics']
+        config['regression_sample_metric'] = ['CRPS']       # the typo
+        with pytest.raises(ValueError, match="closely resembles"):
+            NativeEvaluator(config)

--- a/tests/test_native_evaluator.py
+++ b/tests/test_native_evaluator.py
@@ -163,14 +163,67 @@ class TestNativeEvaluatorGreen:
             },
             metadata={'target': 'test_target'},
         )
+        # ADR-015 ruling 7: this used to return step03/step04 as EMPTY DICTS —
+        # requested by the caller, present in the report, looking evaluated, scoring
+        # nothing and emitting no MetricFrame rows. Silently not fulfilling an explicit
+        # request is now a loud failure (C-20, truncation half).
         config = _regression_point_config(steps=[1, 2, 3, 4])
+        with pytest.raises(ValueError, match="legacy_compatibility=True truncates"):
+            NativeEvaluator(config).evaluate(ef, legacy_compatibility=True)
+
+    def test_legacy_compatibility_true_succeeds_when_only_available_steps_requested(self):
+        """Truncation itself is still supported — ask only for steps that exist.
+
+        The flag's legacy-parity purpose is preserved: the caller declares the steps
+        the shortest sequence can supply and gets exactly those, fully scored.
+        """
+        rows = []
+        for s in range(1, 5):   # origin 0: 4 steps
+            rows.append((100 + s - 1, 1, 0, s))
+        for s in range(1, 3):   # origin 1: 2 steps
+            rows.append((101 + s - 1, 1, 1, s))
+        n = len(rows)
+        ef = EvaluationFrame(
+            y_true=np.zeros(n),
+            y_pred=np.zeros((n, 1)),
+            identifiers={
+                'time':   np.array([r[0] for r in rows]),
+                'unit':   np.array([r[1] for r in rows]),
+                'origin': np.array([r[2] for r in rows]),
+                'step':   np.array([r[3] for r in rows]),
+            },
+            metadata={'target': 'test_target'},
+        )
+        config = _regression_point_config(steps=[1, 2])   # only what origin 1 can supply
         report = NativeEvaluator(config).evaluate(ef, legacy_compatibility=True)
         step_results = report.to_dict()['schemas']['step']
-        # Steps 1 and 2 should be populated; steps 3 and 4 should be empty (truncated)
-        assert bool(step_results.get('step01'))  # non-empty dict
-        assert bool(step_results.get('step02'))  # non-empty dict
-        assert not step_results.get('step03')    # empty dict (truncated)
-        assert not step_results.get('step04')    # empty dict (truncated)
+        assert bool(step_results.get('step01'))
+        assert bool(step_results.get('step02'))
+        assert set(step_results) == {'step01', 'step02'}, \
+            "no empty placeholder keys should survive"
+
+    def test_legacy_compatibility_true_is_a_noop_for_equal_length_origins(self):
+        """Equal-length sequences truncate nothing, so the flag must not interfere."""
+        rows = []
+        for o in (0, 1):
+            for s in range(1, 4):
+                rows.append((100 + o + s - 1, 1, o, s))
+        n = len(rows)
+        ef = EvaluationFrame(
+            y_true=np.zeros(n),
+            y_pred=np.zeros((n, 1)),
+            identifiers={
+                'time':   np.array([r[0] for r in rows]),
+                'unit':   np.array([r[1] for r in rows]),
+                'origin': np.array([r[2] for r in rows]),
+                'step':   np.array([r[3] for r in rows]),
+            },
+            metadata={'target': 'test_target'},
+        )
+        config = _regression_point_config(steps=[1, 2, 3])
+        report = NativeEvaluator(config).evaluate(ef, legacy_compatibility=True)
+        step_results = report.to_dict()['schemas']['step']
+        assert all(bool(step_results.get(f'step0{s}')) for s in (1, 2, 3))
 
     def test_legacy_compatibility_false_includes_all_steps_with_data(self):
         """With legacy_compatibility=False, all steps that have data are populated."""
@@ -373,7 +426,11 @@ class TestNativeEvaluatorBeige:
     def test_nan_metric_result_is_finite_checkable(self):
         """Metric results that are NaN (e.g., Pearson on constant data) must be
         detectable via np.isfinite. This documents that NaN can appear in results
-        when data is degenerate, and callers should check."""
+        when data is degenerate, and callers should check.
+
+        ADR-015 ruling 2 (as revised): a constant series is a property of the data,
+        not a fault, so this is a documented sentinel rather than a raise.
+        """
         n = 4
         ef = EvaluationFrame(
             y_true=np.array([1.0, 1.0, 1.0, 1.0]),  # constant → Pearson = NaN
@@ -393,6 +450,36 @@ class TestNativeEvaluatorBeige:
         assert np.isnan(pearson_val), "Pearson on constant data should be NaN"
         # Callers can detect this with np.isfinite
         assert not np.isfinite(pearson_val)
+
+    def test_constant_baseline_model_evaluates_without_crashing(self):
+        """Regression guard for the ADR-015 ruling-2 reversal (2026-08-02).
+
+        A "predict zero everywhere" baseline has a constant prediction series. ADR-041
+        states reports exist to compare "ensemble models against constituent models and
+        baselines", so this is a routine workflow.
+
+        For one day, Pearson raised on constant input — which aborted the ENTIRE
+        evaluation (every metric, every schema) whenever a baseline was scored. This
+        test pins that it must not happen again: the baseline evaluates, MSE is real,
+        and Pearson records NaN for the undefined groups.
+        """
+        n = 6
+        ef = EvaluationFrame(
+            y_true=np.array([0.0, 5.0, 0.0, 12.0, 3.0, 0.0]),   # varied, real data
+            y_pred=np.zeros((n, 1)),                             # the baseline
+            identifiers={
+                'time':   np.array([100, 100, 100, 101, 101, 101]),
+                'unit':   np.array([1, 2, 3, 1, 2, 3]),
+                'origin': np.zeros(n, dtype=int),
+                'step':   np.array([1, 1, 1, 2, 2, 2]),
+            },
+            metadata={'target': 'test_target'},
+        )
+        config = _regression_point_config(steps=[1, 2], metrics=['MSE', 'Pearson'])
+        report = NativeEvaluator(config).evaluate(ef)          # must not raise
+        month = report.to_dict()['schemas']['month']
+        assert np.isfinite(month['month100']['MSE']), "MSE must still be computed"
+        assert np.isnan(month['month100']['Pearson']), "Pearson undefined → NaN, not a crash"
 
     def test_cross_schema_consistency_mse_values(self):
         """MSE computed via month-wise on a single-month window must equal
@@ -480,21 +567,107 @@ class TestNativeEvaluatorRed:
             NativeEvaluator(config).evaluate(ef)
 
     def test_invalid_metric_name_raises_value_error(self):
-        ef = _make_parallelogram_ef(n_origins=1, n_steps=2, n_units=2)
+        """Unknown metric names now fail at construction, not at evaluate() (C-02)."""
         config = _regression_point_config(steps=[1, 2], metrics=['NOSUCHMETRIC'])
-        with pytest.raises(ValueError, match="not valid"):
-            NativeEvaluator(config).evaluate(ef)
+        with pytest.raises(ValueError, match="Unknown metric"):
+            NativeEvaluator(config)
 
-    def test_empty_config_accepted_at_init_fails_at_evaluate(self):
-        """Empty config is accepted at init (C-02 known gap) but fails at evaluate().
+    def test_empty_config_rejected_at_init(self):
+        """An empty config fails loudly at construction (C-02, ADR-015 rulings 4/5).
 
-        NativeEvaluator.__init__ only validates profile name (defaults to 'base').
-        Structural config errors surface at evaluate() time, not construction.
+        Supersedes ``test_empty_config_accepted_at_init_fails_at_evaluate``, which
+        asserted the pre-ADR-015 behaviour: that ``NativeEvaluator({})`` constructed
+        successfully and only failed later. That leniency was the Tier-1 defect.
         """
-        ef = _make_parallelogram_ef(n_origins=1, n_steps=2, n_units=2)
-        evaluator = NativeEvaluator({})  # does NOT raise — C-02
-        with pytest.raises((ValueError, KeyError)):
-            evaluator.evaluate(ef)
+        with pytest.raises(ValueError):
+            NativeEvaluator({})
+
+    # ── C-02 / ADR-015 rulings 4 & 5: config must fail loud at construction ──────
+    #
+    # Each of these previously produced an empty-but-successful-looking report.
+
+    def test_misspelled_metric_list_key_rejected_at_init(self):
+        """The exact C-02 reproduction: a missing 's' silently emptied the report."""
+        config = {
+            'steps': [1],
+            'regression_targets': ['target'],
+            'regression_sample_metric': ['CRPS'],   # typo — should be ..._metrics
+        }
+        with pytest.raises(ValueError, match="Unknown evaluation config key"):
+            NativeEvaluator(config)
+
+    def test_legacy_config_keys_rejected_at_init(self):
+        """Legacy keys removed in 0.4.0 now fail loudly instead of silently (C-29)."""
+        for legacy in ('targets', 'metrics',
+                       'regression_uncertainty_metrics', 'classification_uncertainty_metrics'):
+            config = {'steps': [1], 'regression_targets': ['target'],
+                      'regression_point_metrics': ['MSE'], legacy: ['x']}
+            with pytest.raises(ValueError, match="Unknown evaluation config key"):
+                NativeEvaluator(config)
+
+    def test_missing_steps_rejected_at_init(self):
+        """Without 'steps' the entire step-wise schema was silently absent."""
+        config = {'regression_targets': ['target'], 'regression_sample_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="non-empty 'steps'"):
+            NativeEvaluator(config)
+
+    def test_empty_steps_rejected_at_init(self):
+        config = {'steps': [], 'regression_targets': ['target'],
+                  'regression_sample_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="non-empty 'steps'"):
+            NativeEvaluator(config)
+
+    def test_non_positive_step_rejected_at_init(self):
+        """'steps' is 1-indexed; step 0 would silently match no group."""
+        config = {'steps': [0, 1], 'regression_targets': ['target'],
+                  'regression_sample_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="1-indexed positive integers"):
+            NativeEvaluator(config)
+
+    def test_no_targets_rejected_at_init(self):
+        config = {'steps': [1], 'regression_sample_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="declares no targets"):
+            NativeEvaluator(config)
+
+    def test_targets_without_metrics_rejected_at_init(self):
+        """Declaring a task with no metrics for it evaluated every group to {}."""
+        config = {'steps': [1], 'regression_targets': ['target']}
+        with pytest.raises(ValueError, match="provides no metrics"):
+            NativeEvaluator(config)
+
+    def test_metric_invalid_for_its_cell_rejected_at_init(self):
+        """CRPS is a sample metric; declaring it under point metrics is a config error."""
+        config = {'steps': [1], 'regression_targets': ['target'],
+                  'regression_point_metrics': ['CRPS']}
+        with pytest.raises(ValueError, match="not valid for"):
+            NativeEvaluator(config)
+
+    def test_non_dict_config_rejected_at_init(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            NativeEvaluator(['steps', 1])
+
+    def test_sample_frame_without_sample_metrics_fails_at_evaluate(self):
+        """pred_type depends on the frame, so this can only be caught at evaluate().
+
+        A point-only config evaluating a sample frame previously produced empty
+        per-group dicts with no error.
+        """
+        # Built inline: the shared helper is point-only (y_pred is (n, 1)).
+        ef = EvaluationFrame(
+            y_true=np.zeros(4),
+            y_pred=np.zeros((4, 3)),          # 3 samples per row -> pred_type == 'sample'
+            identifiers={
+                'time':   np.array([100, 100, 101, 101]),
+                'unit':   np.array([1, 2, 1, 2]),
+                'origin': np.array([0, 0, 0, 0]),
+                'step':   np.array([1, 1, 2, 2]),
+            },
+            metadata={'target': 'test_target'},
+        )
+        config = {'steps': [1, 2], 'regression_targets': ['test_target'],
+                  'regression_point_metrics': ['MSE']}
+        with pytest.raises(ValueError, match="No metrics configured for"):
+            NativeEvaluator(config).evaluate(ef)
 
     def test_metric_function_error_includes_metric_name(self):
         """When a metric function raises, the error message must name the metric (C-16)."""

--- a/views_evaluation/evaluation/config_schema.py
+++ b/views_evaluation/evaluation/config_schema.py
@@ -1,9 +1,17 @@
 """
 Typed schema for evaluation config dicts.
 
-Type-checking only — no runtime enforcement. Regular dicts continue to work
-at runtime. This TypedDict documents the expected config structure and
-enables IDE autocompletion and static analysis (mypy, pyright).
+This TypedDict is the **single authority** for which config keys the evaluator
+understands. It serves two purposes:
+
+  1. Static analysis — documents the expected structure and enables IDE
+     autocompletion and type checking (mypy, pyright).
+  2. **Runtime validation** — ``NativeEvaluator._validate_config`` derives its
+     valid key set directly from ``EvaluationConfig.__annotations__``, so adding
+     a key here is all that is required to have the evaluator accept it. There is
+     no second, hand-maintained list to keep in step.
+
+Regular dicts continue to work at runtime; the TypedDict is never instantiated.
 """
 
 from typing import Any, Dict, List, TypedDict
@@ -13,9 +21,14 @@ class EvaluationConfig(TypedDict, total=False):
     """
     Config dict for NativeEvaluator.
 
-    All keys are optional (total=False) to match the existing .get() patterns.
-    Downstream validators (EvaluationManager._validate_config) enforce
-    required-key semantics at runtime.
+    All keys are ``total=False`` for typing purposes only — that does NOT mean they
+    are optional at runtime. ``NativeEvaluator._validate_config`` enforces which keys
+    are actually required (``steps``, at least one target list, and at least one
+    metric list per declared task), raising at construction if they are absent.
+
+    (Until 0.4.0 this docstring named ``EvaluationManager._validate_config`` as the
+    enforcer. That class was removed in Phase 3 and validation was unowned until
+    0.5.0 — risk register C-02.)
 
     Keys:
         steps: List of 1-indexed step positions to evaluate.

--- a/views_evaluation/evaluation/evaluation_frame.py
+++ b/views_evaluation/evaluation/evaluation_frame.py
@@ -34,7 +34,20 @@ class EvaluationFrame:
         if y_pred.dtype == object:
             raise ValueError("y_pred must be numeric (got dtype=object)")
 
-        # Rectangular sample validation: y_pred must be a dense 2D array
+        # Shape contract. Both halves live here, after the dtype gate, so a
+        # non-numeric array is reported as a dtype problem rather than a shape one.
+        #
+        # C-31 — y_true must be 1D. Without this an un-squeezed (N, 1) column (a common
+        # shape out of a DataFrame column or a model head) constructed fine and reported
+        # a plausible n_rows, failing much later inside _guard_shapes as a *metric*
+        # error rather than an input-contract one. ADR-014: the frame is the single
+        # validation gate, so both operands are checked here.
+        if y_true.ndim != 1:
+            raise ValueError(
+                f"y_true must be 1D (N,), got {y_true.ndim}D with shape {y_true.shape}"
+            )
+
+        # Rectangular sample validation: y_pred must be a dense 2D array (C-03)
         if y_pred.ndim != 2:
             raise ValueError(
                 f"y_pred must be 2D (N, S), got {y_pred.ndim}D with shape {y_pred.shape}"

--- a/views_evaluation/evaluation/evaluation_report.py
+++ b/views_evaluation/evaluation/evaluation_report.py
@@ -128,10 +128,16 @@ class EvaluationReport:
         # genuine import errors inside numpy/metric_frame then propagate loudly (not masked).
         import importlib.util
         if importlib.util.find_spec("views_frames") is None:
-            raise ImportError(
+            # Level-1 emit path: logs before raising even though this guard physically
+            # resides in a Level-0 file. Logging follows the emit path, not the file
+            # (logging standard §5.1). No other raise in this module logs.
+            import logging
+            err_msg = (
                 "EvaluationReport.to_metric_frame() requires the optional 'views-frames' "
                 "dependency. Install it with: pip install views-evaluation[frames]"
             )
+            logging.getLogger("views_evaluation.evaluation.metric_frame").error(err_msg)
+            raise ImportError(err_msg)
         import numpy as np
         from views_frames import FrameMetadata
         from views_evaluation.evaluation.metric_frame import (
@@ -184,6 +190,27 @@ class EvaluationReport:
                 arr = np.asarray(metric_values[metric], dtype=np.float64)
                 mean = float("nan") if np.all(np.isnan(arr)) else float(np.nanmean(arr))
                 _emit(eval_type, metric, MEAN_GROUP_ID, mean)
+
+        # ADR-015 ruling 6: an empty emit produces a structurally valid zero-row
+        # MetricFrame that passes every envelope check and persists to disk as a
+        # legitimate audit artifact — indistinguishable from a real one, and rendering
+        # downstream as "not calculated" exactly like a genuine metric failure.
+        # The evaluation-of-record must never record nothing while looking complete.
+        if not values:
+            present = sorted(k for k, v in self._results.items() if v)
+            empty = sorted(k for k, v in self._results.items() if not v)
+            err_msg = (
+                f"to_metric_frame() produced no rows — the report contains no metric "
+                f"values for any schema, so the emitted evaluation-of-record would be "
+                f"empty. Target='{self.target}', task='{self.task}', "
+                f"pred_type='{self.pred_type}'. Schemas with groups but no metric "
+                f"values: {present or 'none'}; schemas with no groups: {empty or 'none'}. "
+                f"This usually means the evaluator was misconfigured."
+            )
+            # Level-1 emit path: log before raising (logging standard §5.1).
+            import logging
+            logging.getLogger("views_evaluation.evaluation.metric_frame").error(err_msg)
+            raise ValueError(err_msg)
 
         values_arr = np.asarray(values, dtype=np.float32).reshape(-1, 1)
         identifiers = {axis: np.asarray(columns[axis], dtype=str) for axis in AXES}

--- a/views_evaluation/evaluation/metric_catalog.py
+++ b/views_evaluation/evaluation/metric_catalog.py
@@ -85,6 +85,12 @@ METRIC_CATALOG: Dict[str, MetricSpec] = {
     "QIS":       MetricSpec(function=calculate_quantile_interval_score_native,
                             genome=("lower_quantile", "upper_quantile")),
     "Coverage":  MetricSpec(function=calculate_coverage_native,  genome=("alpha",)),
+    # ⚠ `low_bin` and `high_bin` are RESERVED PLACEHOLDERS that currently have NO EFFECT
+    #   (np.histogram_bin_edges ignores range= when bins is a sequence). They are
+    #   required by this genome and validated as present, but changing them alters
+    #   nothing. Use-it-or-lose-it — see the status block in
+    #   calculate_ignorance_score_native's docstring for the activation spec, and risk
+    #   register C-28(b).
     "Ignorance": MetricSpec(function=calculate_ignorance_score_native,
                             genome=("bins", "low_bin", "high_bin")),
 

--- a/views_evaluation/evaluation/metric_frame.py
+++ b/views_evaluation/evaluation/metric_frame.py
@@ -28,6 +28,7 @@ Importing this module requires the optional ``views-frames`` dependency
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -35,6 +36,10 @@ from typing import Any, Dict, Optional, Union
 import numpy as np
 
 from views_frames import FrameMetadata
+
+# Level-1 component: logs at ERROR before raising (logging standard §5.1).
+# The Level-0 pure-math modules are exempt and must NOT acquire loggers.
+logger = logging.getLogger(__name__)
 
 # ── Vocabulary authority ────────────────────────────────────────────────────────
 # The single mapping from views-evaluation's internal schema names to the
@@ -65,7 +70,9 @@ def _json_default(obj: Any) -> Any:
         return float(obj)
     if isinstance(obj, np.bool_):
         return bool(obj)
-    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+    err_msg = f"Object of type {type(obj).__name__} is not JSON serializable"
+    logger.error(err_msg)
+    raise TypeError(err_msg)
 
 
 def default_scoring_code_version() -> Optional[str]:
@@ -144,33 +151,45 @@ class MetricFrame:
     def _validate(values: np.ndarray, identifiers: Dict[str, np.ndarray]) -> None:
         # ADR-013 fail-loud: structural envelope guarantees, checked at construction.
         if not isinstance(values, np.ndarray):
-            raise ValueError(f"values must be a numpy array, got {type(values).__name__}")
+            err_msg = f"values must be a numpy array, got {type(values).__name__}"
+            logger.error(err_msg)
+            raise ValueError(err_msg)
         if values.dtype != np.float32:
-            raise ValueError(f"values must be float32, got {values.dtype}")
+            err_msg = f"values must be float32, got {values.dtype}"
+            logger.error(err_msg)
+            raise ValueError(err_msg)
         if values.ndim != 2:
-            raise ValueError(
+            err_msg = (
                 f"values must be 2D (N, 1) with an explicit trailing axis, got {values.ndim}D "
                 f"with shape {values.shape}"
             )
+            logger.error(err_msg)
+            raise ValueError(err_msg)
 
         n_rows = values.shape[0]
         missing = set(AXES) - set(identifiers.keys())
         if missing:
-            raise ValueError(
+            err_msg = (
                 f"MetricFrame identifiers missing required axes: {sorted(missing)}. "
                 f"Required: {list(AXES)}"
             )
+            logger.error(err_msg)
+            raise ValueError(err_msg)
         for key in AXES:
             arr = identifiers[key]
             if getattr(arr, "ndim", None) != 1:
-                raise ValueError(
+                err_msg = (
                     f"Identifier '{key}' must be a 1D array, got "
                     f"{getattr(arr, 'ndim', '?')}D with shape {getattr(arr, 'shape', '?')}"
                 )
+                logger.error(err_msg)
+                raise ValueError(err_msg)
             if len(arr) != n_rows:
-                raise ValueError(
+                err_msg = (
                     f"Identifier '{key}' length ({len(arr)}) mismatch values rows ({n_rows})"
                 )
+                logger.error(err_msg)
+                raise ValueError(err_msg)
 
     @property
     def n_rows(self) -> int:

--- a/views_evaluation/evaluation/native_evaluator.py
+++ b/views_evaluation/evaluation/native_evaluator.py
@@ -25,17 +25,114 @@ class NativeEvaluator:
         metric_hyperparameters (dict): Optional per-metric overrides.
             E.g. {"twCRPS": {"threshold": 2.0}, "Coverage": {"alpha": 0.05}}
     """
-    def __init__(self, config: EvaluationConfig):
-        self.config = config
+    # Config keys this evaluator understands, derived from the EvaluationConfig
+    # TypedDict so the schema has exactly one authority (ADR-012). Adding a key
+    # there is all that is required to support it here.
+    _VALID_CONFIG_KEYS = frozenset(EvaluationConfig.__annotations__)
 
-        # Resolve evaluation profile
+    # Each metric-list key declares the (task, pred_type) cell it supplies metrics for.
+    _METRIC_LIST_KEYS = {
+        "regression_point_metrics":      ("regression", "point"),
+        "regression_sample_metrics":     ("regression", "sample"),
+        "classification_point_metrics":  ("classification", "point"),
+        "classification_sample_metrics": ("classification", "sample"),
+    }
+
+    @classmethod
+    def _validate_config(cls, config: EvaluationConfig) -> None:
+        """
+        Fail loud on a structurally invalid config, at construction (ADR-015 rulings 4/5).
+
+        Before this existed, a misspelled metric-list key or an absent ``steps`` key
+        produced an empty-but-successful-looking report instead of an error
+        (risk register C-02, Tier 1). Nothing is defaulted or repaired here — an
+        invalid config is the caller's to fix (ADR-015).
+        """
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"Evaluation config must be a dict, got {type(config).__name__}."
+            )
+
+        # 0. Profile name. Checked first so the pre-existing "Unknown evaluation
+        #    profile" contract is preserved exactly for configs that hit both this
+        #    and a structural problem below.
         profile_name = config.get("evaluation_profile", "base")
         if profile_name not in PROFILES:
             raise ValueError(
                 f"Unknown evaluation profile '{profile_name}'. "
                 f"Available: {sorted(PROFILES.keys())}"
             )
-        self.profile = PROFILES[profile_name]
+
+        # 1. Unknown / misspelled keys. Also the loud failure for legacy keys
+        #    ('targets', 'metrics', '*_uncertainty_metrics') removed in 0.4.0.
+        unknown = sorted(set(config) - cls._VALID_CONFIG_KEYS)
+        if unknown:
+            raise ValueError(
+                f"Unknown evaluation config key(s): {unknown}. "
+                f"Valid keys: {sorted(cls._VALID_CONFIG_KEYS)}. "
+                f"Note: the legacy keys 'targets', 'metrics', "
+                f"'regression_uncertainty_metrics' and 'classification_uncertainty_metrics' "
+                f"were removed in 0.4.0 — see the README migration table."
+            )
+
+        # 2. 'steps' is required (CIC NativeEvaluator §4) and drives the step-wise schema.
+        #    Absent, it silently produced no step-wise results at all.
+        if not config.get("steps"):
+            raise ValueError(
+                "Evaluation config requires a non-empty 'steps' list (1-indexed step "
+                "positions to evaluate, e.g. [1, 2, 3]). Without it the step-wise "
+                "schema cannot be produced."
+            )
+        bad_steps = [s for s in config["steps"]
+                     if not isinstance(s, int) or isinstance(s, bool) or s < 1]
+        if bad_steps:
+            raise ValueError(
+                f"Evaluation config 'steps' must contain 1-indexed positive integers; "
+                f"got invalid entries: {bad_steps}."
+            )
+
+        # 3. At least one target list must be declared, or nothing can be evaluated.
+        declared_tasks = [
+            task for task in ("regression", "classification")
+            if config.get(f"{task}_targets")
+        ]
+        if not declared_tasks:
+            raise ValueError(
+                "Evaluation config declares no targets. Provide a non-empty "
+                "'regression_targets' and/or 'classification_targets'."
+            )
+
+        # 4. Each declared task needs at least one metric list, else every group
+        #    for that task evaluates to an empty dict.
+        for task in declared_tasks:
+            if not any(config.get(f"{task}_{pred_type}_metrics")
+                       for pred_type in ("point", "sample")):
+                raise ValueError(
+                    f"Evaluation config declares '{task}_targets' but provides no "
+                    f"metrics for it. Add a non-empty '{task}_point_metrics' and/or "
+                    f"'{task}_sample_metrics'."
+                )
+
+        # 5. Every named metric must exist and be valid for the cell its key declares.
+        for key, cell in cls._METRIC_LIST_KEYS.items():
+            for metric in config.get(key, []):
+                if metric not in METRIC_CATALOG:
+                    raise ValueError(
+                        f"Unknown metric '{metric}' in '{key}'. "
+                        f"Available: {sorted(METRIC_CATALOG)}."
+                    )
+                if metric not in METRIC_MEMBERSHIP[cell]:
+                    raise ValueError(
+                        f"Metric '{metric}' in '{key}' is not valid for {cell}. "
+                        f"Valid for {cell}: {sorted(METRIC_MEMBERSHIP[cell])}."
+                    )
+
+    def __init__(self, config: EvaluationConfig):
+        self._validate_config(config)
+        self.config = config
+
+        # Profile name was validated in _validate_config (check 0).
+        self.profile = PROFILES[config.get("evaluation_profile", "base")]
         self.metric_overrides = config.get("metric_hyperparameters", {})
 
     def _resolve_task_and_metrics(self, ef: EvaluationFrame):
@@ -50,6 +147,17 @@ class NativeEvaluator:
 
         pred_type = "sample" if ef.is_sample else "point"
         metrics_list = self.config.get(f"{task}_{pred_type}_metrics", [])
+
+        # ADR-015 ruling 4: an empty metric list yields an empty-but-successful-looking
+        # report. Construction-time validation cannot catch this case, because pred_type
+        # is a property of the frame (n_samples > 1), not of the config.
+        if not metrics_list:
+            raise ValueError(
+                f"No metrics configured for ({task}, {pred_type}). The frame for target "
+                f"'{target}' has {ef.n_samples} sample(s) per row, so it is a "
+                f"'{pred_type}' evaluation and requires a non-empty "
+                f"'{task}_{pred_type}_metrics' list in the config."
+            )
 
         return metrics_list, task, pred_type
 
@@ -115,6 +223,22 @@ class NativeEvaluator:
                 # Count unique steps per origin
                 seq_lengths.append(len(np.unique(ef.identifiers['step'][idx])))
             max_allowed_step = min(seq_lengths) if seq_lengths else 0
+
+            # ADR-015 ruling 7: config['steps'] is a request list, not a hint. Truncated
+            # steps were left as pre-initialised empty dicts, so a requested step came
+            # back looking evaluated while scoring nothing and emitting no MetricFrame
+            # rows — the same silent-empty pattern as C-02. Silently not fulfilling an
+            # explicit request is a contract violation regardless of which flag was set.
+            dropped = sorted(s for s in config_steps if s > max_allowed_step)
+            if dropped:
+                raise ValueError(
+                    f"legacy_compatibility=True truncates step-wise evaluation at step "
+                    f"{max_allowed_step} (the shortest origin sequence has "
+                    f"{max_allowed_step} step(s)), but config['steps'] explicitly "
+                    f"requested {dropped}, which would be silently omitted. Either "
+                    f"remove {dropped} from 'steps', or set legacy_compatibility=False "
+                    f"to evaluate every step that has data."
+                )
 
         step_indices = ef.get_group_indices('step')
         for step, idx in step_indices.items():

--- a/views_evaluation/evaluation/native_evaluator.py
+++ b/views_evaluation/evaluation/native_evaluator.py
@@ -19,11 +19,28 @@ class NativeEvaluator:
     pattern for hyperparameter resolution:
         model overrides → evaluation profile → fail loud
 
-    Config keys:
+    The config is validated at construction, not at evaluate() — an invalid config
+    raises immediately rather than producing an empty-but-successful-looking report
+    (ADR-015, risk register C-02). See `_validate_config` for the full rules and
+    `documentation/CICs/NativeEvaluator.md` for the authoritative contract.
+
+    Required config keys:
+        steps (list[int]): 1-indexed step positions to evaluate. Must be non-empty.
+        regression_targets and/or classification_targets (list[str]): at least one
+            must be non-empty, and each declared task needs at least one metric list.
+        <task>_<pred_type>_metrics (list[str]): e.g. regression_sample_metrics.
+            Names must exist in METRIC_CATALOG and be valid for that cell.
+
+    Optional config keys:
         evaluation_profile (str): Name of the evaluation profile to use.
             Must be a key in PROFILES. Defaults to "base" during transition.
         metric_hyperparameters (dict): Optional per-metric overrides.
             E.g. {"twCRPS": {"threshold": 2.0}, "Coverage": {"alpha": 0.05}}
+
+    Unrecognised keys are tolerated — views-pipeline-core passes its whole combined
+    model config through — EXCEPT keys that closely resemble a real evaluation key
+    (a suspected typo) or legacy keys removed in 0.4.0, both of which raise. A
+    suspected typo is reported, never substituted (register C-33).
     """
     # Config keys this evaluator understands, derived from the EvaluationConfig
     # TypedDict so the schema has exactly one authority (ADR-012). Adding a key

--- a/views_evaluation/evaluation/native_evaluator.py
+++ b/views_evaluation/evaluation/native_evaluator.py
@@ -30,6 +30,48 @@ class NativeEvaluator:
     # there is all that is required to support it here.
     _VALID_CONFIG_KEYS = frozenset(EvaluationConfig.__annotations__)
 
+    # Config keys removed in 0.4.0, mapped to what replaces them. An explicit,
+    # enumerated set — presence is detected by exact name, never by inference, and
+    # the value is never translated on the caller's behalf.
+    _LEGACY_CONFIG_KEYS = {
+        "targets": "regression_targets' or 'classification_targets",
+        "metrics": "regression_point_metrics",
+        "regression_uncertainty_metrics": "regression_sample_metrics",
+        "classification_uncertainty_metrics": "classification_sample_metrics",
+    }
+
+    @staticmethod
+    def _differs_by_one_edit(a: str, b: str) -> bool:
+        """True if `a` and `b` differ by exactly one insertion, deletion or substitution."""
+        if a == b or abs(len(a) - len(b)) > 1:
+            return False
+        if len(a) == len(b):
+            return sum(x != y for x, y in zip(a, b)) == 1
+        shorter, longer = (a, b) if len(a) < len(b) else (b, a)
+        return any(longer[:i] + longer[i + 1:] == shorter for i in range(len(longer)))
+
+    @classmethod
+    def _nearest_config_key(cls, key: str):
+        """The evaluation config key `key` appears to be a typo of, or None.
+
+        Used only to *report* a suspected typo. The result is never substituted for
+        the caller's key — see `_validate_config` step 1b.
+
+        Two rules, tuned against the real key set in views-models to flag genuine
+        typos while ignoring the foreign keys that arrive via pipeline-core's combined
+        config. `regression_point_baselines` (a real pipeline-core key) must NOT match
+        `regression_point_metrics`; `regression_sample_metric` and `step` must.
+        """
+        import difflib
+
+        close = difflib.get_close_matches(key, cls._VALID_CONFIG_KEYS, n=1, cutoff=0.9)
+        if close:
+            return close[0]
+        for valid in sorted(cls._VALID_CONFIG_KEYS):
+            if cls._differs_by_one_edit(key, valid):
+                return valid
+        return None
+
     # Each metric-list key declares the (task, pred_type) cell it supplies metrics for.
     _METRIC_LIST_KEYS = {
         "regression_point_metrics":      ("regression", "point"),
@@ -63,17 +105,44 @@ class NativeEvaluator:
                 f"Available: {sorted(PROFILES.keys())}"
             )
 
-        # 1. Unknown / misspelled keys. Also the loud failure for legacy keys
-        #    ('targets', 'metrics', '*_uncertainty_metrics') removed in 0.4.0.
-        unknown = sorted(set(config) - cls._VALID_CONFIG_KEYS)
-        if unknown:
-            raise ValueError(
-                f"Unknown evaluation config key(s): {unknown}. "
-                f"Valid keys: {sorted(cls._VALID_CONFIG_KEYS)}. "
-                f"Note: the legacy keys 'targets', 'metrics', "
-                f"'regression_uncertainty_metrics' and 'classification_uncertainty_metrics' "
-                f"were removed in 0.4.0 — see the README migration table."
+        # 1a. Legacy keys, removed in 0.4.0. An explicit, enumerated set — not inferred.
+        legacy_present = sorted(set(config) & set(cls._LEGACY_CONFIG_KEYS))
+        if legacy_present:
+            replacements = "; ".join(
+                f"'{k}' -> '{cls._LEGACY_CONFIG_KEYS[k]}'" for k in legacy_present
             )
+            raise ValueError(
+                f"Legacy evaluation config key(s) present: {legacy_present}. These were "
+                f"removed in 0.4.0 and are NOT translated automatically. Rename them: "
+                f"{replacements}. See the README migration table."
+            )
+
+        # 1b. Near-miss keys — a key that is one small edit away from a real evaluation
+        #     key is almost certainly a typo of it, and a typo silently produces an
+        #     empty report (register C-02). Fail loud, naming what it resembles.
+        #
+        #     The suspected key is REPORTED, NEVER SUBSTITUTED. This code does not
+        #     guess what the caller meant and proceed — that would be exactly the
+        #     silent repair ADR-015 forbids. The caller fixes their config.
+        #
+        #     Unrecognised keys that are NOT near-misses are ignored on purpose.
+        #     views-pipeline-core passes its *combined* model config straight through
+        #     (`NativeEvaluator(context.configs)`), so this dict legitimately carries
+        #     dozens of foreign keys — `batch_size`, `n_epochs`, `algorithm`,
+        #     `regression_point_baselines` and so on. Rejecting unrecognised keys
+        #     wholesale breaks every model in the platform. Do not "tighten" this back
+        #     up without first fixing the config split upstream (register C-33).
+        for key in sorted(set(config) - cls._VALID_CONFIG_KEYS):
+            suspected = cls._nearest_config_key(key)
+            if suspected is not None:
+                raise ValueError(
+                    f"Evaluation config key '{key}' is not recognised, but closely "
+                    f"resembles '{suspected}' — this looks like a typo. It has NOT been "
+                    f"interpreted as '{suspected}'; nothing is assumed on your behalf. "
+                    f"Either correct the key, or rename it so it does not resemble an "
+                    f"evaluation key. Valid evaluation keys: "
+                    f"{sorted(cls._VALID_CONFIG_KEYS)}."
+                )
 
         # 2. 'steps' is required (CIC NativeEvaluator §4) and drives the step-wise schema.
         #    Absent, it silently produced no step-wise results at all.

--- a/views_evaluation/evaluation/native_metric_calculators.py
+++ b/views_evaluation/evaluation/native_metric_calculators.py
@@ -1,9 +1,12 @@
+import warnings
+
 import numpy as np
 from sklearn.metrics import (
     average_precision_score,
     mean_tweedie_deviance,
 )
 from scipy.stats import wasserstein_distance, pearsonr
+from scipy.stats import ConstantInputWarning
 
 def _guard_shapes(y_true: np.ndarray, y_pred: np.ndarray):
     """Internal guard to prevent broadcasting accidents.
@@ -86,11 +89,36 @@ def calculate_emd_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, **
     return np.mean(emd_list)
 
 def calculate_pearson_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, **kwargs) -> float:
+    """
+    Pearson linear correlation between observations and predictions.
+
+    Returns np.nan if either series is constant — correlation requires variance in
+    both, so no coefficient exists for that group.
+
+    A constant series is a **property of the data**, not a broken invariant, so this
+    is a documented sentinel rather than a failure (ADR-015 ruling 2). A constant
+    prediction series means the model is a baseline (e.g. "predict zero everywhere"),
+    which is a finding about the model, not an error; a constant truth series means the
+    group had no variation to correlate against. Both are ordinary in conflict data,
+    where most units are zero most of the time.
+
+    Consumers should treat np.nan as "not computable for this group" and exclude it
+    from aggregates — `EvaluationReport.to_metric_frame()` already does, via nanmean.
+
+    See also `calculate_mcr_native`, which returns inf/nan on a zero-truth group for
+    the same reason: the degenerate case is a fact about the data, not a fault.
+    """
     y_true, y_pred = _guard_shapes(y_true, y_pred)
-    correlation, _ = pearsonr(
-        np.repeat(y_true, y_pred.shape[1]), 
-        y_pred.flatten()
-    )
+
+    observed = np.repeat(y_true, y_pred.shape[1])
+    predicted = y_pred.flatten()
+
+    # Suppress SciPy's ConstantInputWarning: the degenerate case is handled and
+    # contracted above, so the warning is noise rather than signal. Scoped to this
+    # call only — it must never mask a warning from anything else.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConstantInputWarning)
+        correlation, _ = pearsonr(observed, predicted)
     return correlation
 
 def calculate_mtd_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, *, power: float, **kwargs) -> float:
@@ -102,6 +130,10 @@ def calculate_mtd_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, *,
     )
 
 def calculate_mean_prediction_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, **kwargs) -> float:
+    # C-32: this kernel ignores y_true, but it must still guard like every sibling.
+    # Without the call it silently returned a number for shape-mismatched input while
+    # all ~20 neighbouring kernels raised.
+    y_true, y_pred = _guard_shapes(y_true, y_pred)
     return np.mean(y_pred)
 
 def calculate_mcr_native(y_true: np.ndarray, y_pred: np.ndarray, target=None, **kwargs) -> float:
@@ -149,6 +181,63 @@ def calculate_ignorance_score_native(
     high_bin: int,
     **kwargs
 ) -> float:
+    """
+    Ignorance score over a set of bin edges.
+
+    Args:
+        bins: A sequence of bin edges covering the target's domain, supplied by the
+              evaluation profile. Half-open: an observation is in range for
+              ``[bins[0], bins[-1])``.
+        low_bin: **RESERVED — currently has no effect.** See the status block below.
+        high_bin: **RESERVED — currently has no effect.** See the status block below.
+
+    ┌──────────────────────────────────────────────────────────────────────────────┐
+    │ STATUS OF ``low_bin`` / ``high_bin`` — RESERVED PLACEHOLDERS, NOT LIVE        │
+    │ Recorded 2026-08-02. Risk register C-28(b).                                   │
+    └──────────────────────────────────────────────────────────────────────────────┘
+
+    **These two parameters do nothing.** They are passed to
+    ``np.histogram_bin_edges(preds, bins=bins, range=(low_bin, high_bin))``, and NumPy
+    **silently ignores ``range`` whenever ``bins`` is a sequence** — which it always is
+    in every shipped profile. Verified 2026-08-02: computing edges with
+    ``range=(0, 10000)`` and with ``range=(0, 1)`` returns byte-identical arrays.
+
+    So the genome *requires* them, ``resolve_metric_params`` *fails loud* if a profile
+    omits them, and changing them alters nothing. They are retained deliberately as
+    placeholders for planned work, not because they function.
+
+    **This is a use-it-or-lose-it parameter. It does not get to sit here indefinitely.**
+
+    ── If ACTIVATED, they must conform to all of the following ──────────────────────
+
+    1. **They must actually change the binning.** The only way ``range`` takes effect is
+       if ``bins`` is an integer *count* rather than a sequence, in which case NumPy
+       computes that many equal-width bins spanning ``(low_bin, high_bin)``. Supporting
+       that means supporting two mutually exclusive bin-specification modes.
+    2. **Contradictory configuration must fail loud, not be silently resolved**
+       (ADR-013, ADR-015). If ``bins`` is a sequence *and* ``low_bin``/``high_bin`` are
+       supplied, that is a contradiction — the caller has specified the domain twice, in
+       two ways, which may disagree. Raise; do not pick a winner.
+    3. **They must satisfy ``low_bin < high_bin``**, validated in
+       ``resolve_metric_params`` alongside the existing bounds checks for ``alpha`` and
+       the quantile parameters (``metric_catalog.py``, ``_UNIT_INTERVAL_EXCLUSIVE``).
+    4. **They must agree with ADR-015 ruling 8.** An observation outside the bins raises.
+       If ``low_bin``/``high_bin`` become the declared domain of the target, the
+       out-of-range error message must cite *them*, not ``edges[0]``/``edges[-1]``, or
+       the message will point the researcher at the wrong knob.
+    5. **The semantics must be written down** in the profile docstring and in
+       ``CICs/MetricCatalog.md`` — specifically whether they mean "the target's plausible
+       domain" (a declaration about the data) or "the span to divide into bins" (an
+       instruction about the algorithm). Those are different things and only the second
+       is what NumPy's ``range`` does.
+
+    ── If NOT activated ────────────────────────────────────────────────────────────
+
+    Delete them from ``genome`` in ``metric_catalog.py``, from every profile, and from
+    this signature. A required parameter that changes nothing is dead configuration
+    presenting itself as a control, and it will mislead the next person who tries to
+    fix an out-of-range failure by widening ``high_bin`` — which will do nothing at all.
+    """
     y_true, y_pred = _guard_shapes(y_true, y_pred)
     
     def digitize_minus_one(x, edges):
@@ -159,14 +248,36 @@ def calculate_ignorance_score_native(
         preds = y_pred[i]
         truth = float(y_true[i])
 
+        # NOTE: `range` is INERT here — NumPy ignores it whenever `bins` is a sequence,
+        # which it always is in every shipped profile. Retained as a reserved
+        # placeholder; see the status block in this function's docstring (C-28b).
         edges = np.histogram_bin_edges(preds, bins=bins, range=(low_bin, high_bin))
         binned_preds = digitize_minus_one(preds, edges)
         binned_obs = digitize_minus_one([truth], edges)[0]
 
         n_bins = len(edges) - 1
+
+        # ADR-015 ruling 8: an observation outside the configured bins means the
+        # profile's `bins` do not cover the target's domain. That is a configuration
+        # error for the caller to fix — clamping it into an edge bin would silently
+        # redefine the metric exactly at the tails, which is where conflict data
+        # matters most.
+        #
+        # Without this guard both tails failed, differently and badly:
+        #   above -> binned_obs == n_bins, an IndexError (unless a prediction happened
+        #            to also be out of range, which silently made the index valid)
+        #   below -> binned_obs == -1, which negative-indexes into the LAST bin and
+        #            returned a plausible, wrong score with no error at all.
+        if not 0 <= binned_obs < n_bins:
+            raise ValueError(
+                f"Ignorance: observation {truth} at row {i} lies outside the configured "
+                f"bin range [{edges[0]}, {edges[-1]}). Widen 'bins' in the evaluation "
+                f"profile so it covers the target's observed domain."
+            )
+
         bin_counts = np.bincount(binned_preds, minlength=n_bins)
-        smoothed_counts = bin_counts + 1 
-        
+        smoothed_counts = bin_counts + 1
+
         prob = smoothed_counts[binned_obs] / np.sum(smoothed_counts)
         scores.append(-np.log2(prob))
 

--- a/views_evaluation/profiles/base.py
+++ b/views_evaluation/profiles/base.py
@@ -31,9 +31,19 @@ BASE_PROFILE = {
     "Brier_cls_sample": {"threshold": 0.0},  # hurdle event: any fatality (y > 0)
     "Brier_rgs_sample": {"threshold": 0.0},  # hurdle event: any fatality (y > 0)
     "Coverage":      {"alpha": 0.1},
+    # `bins` — explicit half-open bin edges: an observation is in range for [0, 1000.5).
+    #   Outside that, Ignorance raises (ADR-015 ruling 8). Widen THIS list to change the
+    #   accepted domain — it is the only one of the three that has any effect.
+    #
+    # `low_bin` / `high_bin` — ⚠ RESERVED PLACEHOLDERS, CURRENTLY INERT.
+    #   These are required by the Ignorance genome and must be present, but they change
+    #   nothing: NumPy ignores `range=` whenever `bins` is a sequence. Widening
+    #   `high_bin` to fix an out-of-range failure WILL NOT WORK — widen `bins` instead.
+    #   Use-it-or-lose-it; activation spec is in calculate_ignorance_score_native's
+    #   docstring. Risk register C-28(b).
     "Ignorance": {
         "bins": [0, 0.5, 2.5, 5.5, 10.5, 25.5, 50.5, 100.5, 250.5, 500.5, 1000.5],
-        "low_bin": 0,
-        "high_bin": 10000,
+        "low_bin": 0,       # inert — see note above
+        "high_bin": 10000,  # inert — see note above
     },
 }


### PR DESCRIPTION
Implements epic #26. Closes #27–#41 (15 stories).

Risk register: **15 open concerns → 7**, including the register's only **Tier 1** entry.

---

## ⚠️ This PR contains breaking changes

Inputs that previously produced an **empty-but-successful report**, or a silently wrong result, now raise. That is the point of the work — but it means a downstream caller with a latent misconfiguration will start failing where it used to return nothing.

| What now fails | Previously | Issue |
|---|---|---|
| Misspelled/unknown config key | `{'month100': {}, 'month101': {}}` — an empty report that looked successful | #31 |
| Missing `steps` key | The **entire step-wise schema** silently absent (one of three mandated by ADR-032) | #31 |
| Legacy config keys (`targets`, `metrics`, `*_uncertainty_metrics`) | Silently ignored → empty report | #31 |
| Declared task with no metrics for it | Every group evaluated to `{}` | #31 |
| `Ignorance`, observation outside the bin range | `IndexError` above the top edge; **wrong-bin score** below it | #32 |
| `legacy_compatibility=True` dropping a requested step | Returned as an empty placeholder dict, looking evaluated | #37 |
| `to_metric_frame()` on an empty report | Emitted a valid **zero-row** evaluation-of-record that persisted to disk | #34 |
| A profile still passing `low_bin`/`high_bin`… | …is fine — those are **retained** as documented placeholders | #33 |

Each error names what was wrong, what was expected, and what to change.

**Not a breaking change:** `Pearson` still returns `nan` on constant input. It was ruled a raise and reversed the same day — see below.

---

## What this changes

### Governance

**ADR-015 (new) — Degenerate and Empty Results.** ADR-013 mandated fail-loud but never said what a computation should do when there is *nothing to compute*, so every site improvised. That gap was the root cause of register cluster A — 7 of 15 open concerns.

The ADR rules individually on all 8 non-raising paths, using a **fault-vs-data-property** test:

- A malformed config is a **fault** → raise.
- A group where every unit is zero is a **fact about conflict data** → may be recorded.

**ADR-022 — activated** from `Proposed (Deferred)`. Its own listed trigger ("breaking changes begin to incur high coordination costs") fired in the 2026-04-03 incident, where deleting `EvaluationManager` with no prior deprecation crashed 6/6 downstream integration tests. Now defines the public API surface, a one-release-cycle deprecation contract, the `DeprecationWarning`-vs-fail-loud boundary, `0.x` versioning, and a release checklist as the enforcement point.

**Logging standard §5.1** — the Level-0 exemption named three classes and predated `metric_frame.py`, leaving Level 1 uncovered by omission rather than by decision. Now states both levels explicitly.

### A ruling that was made and reversed, deliberately left visible

`Pearson` on constant input was ruled a **raise**, then reversed the same day. A *"predict zero everywhere"* baseline has a constant prediction series, so the raise **aborted the entire evaluation run** — every metric, every schema — for a workflow ADR-041 requires as routine.

The error was in the criterion, not the case: it asked *"is this number a real answer?"*, which sorts by the arithmetic of the degenerate result rather than by what caused it. `MCR`'s `inf` and `Pearson`'s `nan` arise from the same event — data with no variation — so any test separating them was sorting on an irrelevance.

Criterion 1 was rewritten, both rulings are recorded in ADR-015 R2, and a regression guard pins that baselines evaluate. ADR-015 also gained a standing rule: **before ruling that a degenerate case must raise, identify the blast radius** — a raise propagates to the whole `evaluate()` call.

### Notable implementation details

- Config validation derives its valid key set from `EvaluationConfig.__annotations__`, giving that previously type-only module a runtime authority — one schema, one source.
- The empty-metric-list check lives at `evaluate()`, not `__init__`, because `pred_type` is a property of the **frame** (`n_samples > 1`), not of the config. It is the one case that genuinely cannot be caught at construction.
- The vacuous-emit guard is at the **emit site**, not in `MetricFrame._validate`. The container must stay able to hold zero rows so `load()` can read back whatever `save()` wrote; tightening it would break the round-trip and change a published cross-repo envelope.
- `Ignorance`'s `low_bin`/`high_bin` are **inert** (NumPy ignores `range=` when `bins` is a sequence). Retained as documented reserved placeholders by maintainer decision, with an activation spec and tests pinning the status in **both** directions — activating or deleting them each breaks a test, forcing a recorded decision.

### Guard against recurrence

`tests/test_documentation_contracts.py` is restored — its deletion in Phase 3 is *why* the README shipped a promise the package did not keep, undetected for four months. It found real pre-existing drift on its first run: **ADR-042 was never indexed** in `ADRs/README.md`.

`documentation/validate_docs.sh` is now wired into CI. It has existed and worked for months; no workflow ever invoked it.

---

## Verification

**Every commit passes the suite in isolation** (checked in throwaway worktrees, not assumed):

| commit | tests |
|---|---|
| `ae36981` governance | 281 ✅ |
| `709512e` scipy | 281 ✅ |
| `5bdfa92` implementation | 326 ✅ |
| `f118d09` docs + CICs | 326 ✅ |
| `f1dc85c` doc guard + CI | 343 ✅ |
| `dd71a8d` 0.5.0 + register | 343 ✅ |

Counts climb as tests are added. Nothing is broken mid-history, so it bisects.

At HEAD: **343 passed, zero warnings**, `ruff` clean, `validate_docs.sh` green, both examples run.

The `ConstantInputWarning` that the suite emitted for months is gone — it was the observable symptom of an unhandled degenerate case.

---

## Deliberately NOT in this PR

| Excluded | Why |
|---|---|
| **The PyPI publish** | #23 owns it. This PR only makes the repo release-*ready* |
| C-05 (scipy/sklearn in the Level-0 core) | Only the *declaration* half is fixed (#29). Removing them from Level 0 is a reimplementation |
| C-24, C-26 (MetricFrame drift guards, float32/`schema_version`) | Deliberately deferred until **after** 0.5.0 ships, so the guards pin the contract that actually shipped rather than a moving one |
| C-20's positional-`step` semantics | A cross-repo contract question — the producer of `step` lives in pipeline-core |
| C-22 (Pearson `nan` reaching reports) | Reframed as an **accepted documented sentinel**, not a defect. Carries an explicit warning not to "fix" it by making Pearson raise |

---

## Review notes

- **Six existing tests were rewritten.** Each asserted the old broken behaviour — one docstring literally read *"Empty config is accepted at init (C-02 known gap)"*. Every replacement names the test it supersedes and why. This is the part most worth a sceptical read.
- Two other failures during development were **my bugs, not obsolete tests**; there the code was fixed and the tests left untouched.
- All four Intent Contracts are updated, as ADR-021 and the silicon-agent protocol require. Two pre-existing CIC defects were fixed in passing: `NativeEvaluator.md` §3 contradicted §11 and the code on the `legacy_compatibility` default, and §4 omitted the required `unit` identifier.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
