### PR TITLE
fix(provenance): stamp the code that ran; bump pytest to ^9.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ provided they were announced here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`scoring_code_version` now identifies the code that ran.** It appends `+g<sha>` when
+  the package is running from a git worktree (e.g. `1.0.0+g5469690`). A wheel install has
+  no worktree and stamps a bare version exactly as before, so **nothing changes for anyone
+  installing from PyPI** — which is why this does not need a release to take effect where
+  it matters. The population affected is editable/dev installs, and those run from source.
+
+  `importlib.metadata` reports the *installed distribution*, not the executing code. Under
+  an editable install the two drift the moment the source moves ahead of the last
+  `pip install` — measured with the tree at 1.0.0 and the dist-info still at 0.5.0,
+  emitting frames stamped `0.5.0` from 1.0.0 code, in the artifact whose entire purpose is
+  to be the record. A bare version cannot distinguish the two states; a version plus a SHA
+  can. Closes register **C-25**, whose original proposal ("cut the release so the label is
+  meaningful") was falsified — releasing does not help, because the drift is between the
+  install and the source, not between versions.
+
+  The guarding test asserted only that the stamp was a non-empty string, so it was
+  satisfied by precisely the wrong answer. It now asserts the stamp identifies `HEAD`, and
+  a second test pins the wheel case so no SHA is never invented.
+
+### Changed
+
+- **Dev dependency:** `pytest` `^8.3.3` → `^9.0.3`, clearing a Dependabot advisory
+  (`pytest < 9.0.3`, tmpdir handling). Dev-only — not shipped to users. Verified: the full
+  suite passes on pytest 9.1.1.
+
+---
+
 ## [1.0.0] — 2026-08-02
 
 **The API is now stable.** Under `0.x`, ADR-022 §5 allowed breaking changes in a MINOR

--- a/documentation/CICs/MetricFrame.md
+++ b/documentation/CICs/MetricFrame.md
@@ -152,7 +152,7 @@ later = MetricFrame.load("/path/to/run/evaluation")
 
 - **`schema_version` is not enforced on `load()`** — an old frame under a changed format is not rejected loudly. Register **C-26**; the cross-repo wire-contract half of views-frames C-46 is open and is this repo's responsibility.
 - **float64 → float32 cast at emit.** Metric values are computed in float64 and narrowed for the envelope, so the persisted record is less precise than the computed metric. Register **C-26**.
-- **`scoring_code_version` may be ambiguous.** It is the installed package version, not a git SHA (unavailable in a wheel), so two builds of the same version stamp identically. Register **C-25**.
+- **`scoring_code_version` identifies the code that ran, when it can.** It is the installed distribution's version, plus `+g<sha>` when the package is running from a git worktree (e.g. `1.0.0+g5469690`). A wheel install has no worktree and stamps a bare version — a property of the install, not a failure. The SHA exists because `importlib.metadata` reports the *installed distribution*, not the executing code: under an editable install those drift as soon as the source moves ahead of the last `pip install`, and a bare version cannot distinguish the two. Register **C-25**.
 - **Most of the cross-repo contract in §8 is unguarded by CI.** Register **C-24**.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dataframe = ["pandas"]
 frames = ["views-frames"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.3"
+pytest = "^9.0.3"
 ruff = "*"
 properscoring = "^0.1.0"  # Dev-only: used as test oracle for CRPS parity verification
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,7 +1,7 @@
 # Technical Risk Register — views-evaluation
 
 **Last updated:** 2026-08-02
-**Total open concerns:** 13
+**Total open concerns:** 12
 **Governing ADR:** ADR-023
 **Citation convention:** `Location` fields name files and symbols (functions, classes, sections), not line numbers — line numbers drift as soon as anything is inserted above them.
 
@@ -93,17 +93,6 @@ Root-cause groupings (added 2026-06-26; expanded then largely closed 2026-08-02 
 - **Source:** review-rr strategic (2026-06-26), blind-spot analysis
 - **Mitigation path:** Extend the drift-guard test to cover axes / `MEAN_GROUP_ID` / `eval_type` vocabulary / a serialization round-trip; pin the persistence convention jointly with pipeline-core + reporting. (**`schema_version` enforcement at load is owned by C-26(b), not here** — de-duplicated 2026-08-02, as both entries previously claimed the same fix.) See views-reporting C-41 (token drift, consumer side) and C-26 (serialization fidelity).
 - **Note:** Part of causal cluster D (MetricFrame evaluation-of-record). This repo's most consequential cross-repo surface — consumers are actively coding against it. **Governance asymmetry (added 2026-08-02):** this repo *owns* the artifact but its governing decision record is views-frames **ADR-020**, in another repo. Locally, ADR-041 was the nearest thing to an output contract and it asserted the opposite of what the code does (that views-evaluation never persists to disk) until corrected on 2026-08-02, and `MetricFrame` had no Intent Contract until the same date. A contract with no local authoritative statement is easier to drift from — which is the exposure this entry tracks. See also C-34.
-
----
-
-### C-25 — Provenance version-label integrity in the evaluation-of-record
-- **Tier:** 3 (Medium)
-- **Description:** `to_metric_frame()` stamps `scoring_code_version` from the installed package version (`default_scoring_code_version` → `importlib.metadata`), which is currently a stale `"0.4.0"` — PR #20 reverted the version bump (see C-11/C-14). A dev build of views-evaluation and the released 0.4.0 therefore stamp **identical** provenance, so the evaluation-of-record cannot identify which code produced it — undermining the auditability the MetricFrame exists to provide.
-- **Trigger:** When an emitted MetricFrame is used for audit/repro and two different code states both carry `scoring_code_version="0.4.0"`; or when a release moves the label again — 0.5.0 and 1.0.0 both did — and historical dev-build frames remain indistinguishable from it.
-- **Location:** `views_evaluation/evaluation/metric_frame.py` (`default_scoring_code_version`); `pyproject.toml` (`version`)
-- **Source:** review-rr strategic (2026-06-26), blind-spot analysis
-- **Mitigation path — the original proposal is falsified; do not rely on it.** This entry previously said "cut the 0.5.0 release so the label is meaningful". Releasing does not fix it. `default_scoring_code_version()` reads `importlib.metadata.version("views_evaluation")` — the **installed distribution's** metadata, not the code being executed — so in an editable install the two drift freely. **Demonstrated 2026-08-02:** with the source tree at 1.0.0 and the editable dist-info still recording 0.5.0, an emitted MetricFrame carried `scoring_code_version='0.5.0'` while being produced by 1.0.0 code. The platform runs views-evaluation as an editable install, so this is live, not hypothetical: every MetricFrame emitted between a source change and a reinstall is mislabelled, silently. Real options: stamp a git SHA alongside the version when a repository is detectable; or verify the installed metadata against the running package at emit time and fail loud on mismatch (ADR-013), which turns a silent wrong label into a loud one. See also C-11 / C-14.
-- **Note:** Part of causal cluster D.
 
 ---
 
@@ -227,6 +216,7 @@ Moved out of the register (no correctness/reliability dimension) — tracked in 
 
 | ID | Tier | Description | Resolution | Issue |
 |----|------|-------------|------------|-------|
+| C-25 | 3 | Provenance version-label integrity in the evaluation-of-record | `default_scoring_code_version()` now appends `+g<sha>` when the package runs from a git worktree, so the stamp identifies the executing code rather than the last `pip install`. A wheel install has no worktree and stamps a bare version — a property of the install, not a failure (ADR-015). The entry's original proposal, "cut the 0.5.0 release so the label is meaningful", was falsified: releasing does not help, because the drift is between the installed distribution and the source tree, not between versions. Demonstrated with the tree at 1.0.0 and the dist-info at 0.5.0 emitting frames stamped `0.5.0`. The guarding test previously asserted only that the stamp was a non-empty string, so it was satisfied by exactly the wrong answer; it now asserts the stamp identifies HEAD. | #57 |
 | C-02 | **1** | NativeEvaluator does not validate config at init | `_validate_config()` added to `__init__`: rejects unknown/misspelled keys (valid set derived from `EvaluationConfig.__annotations__`), missing/empty/non-positive `steps`, absent target lists, declared tasks with no metrics, and invalid metric names. A resolved `(task, pred_type)` with no metrics now raises at `evaluate()` — the one case that cannot be known at construction. Covered by every `TestNativeEvaluatorRed::test_*_rejected_at_init` case. | #31 |
 | C-13 | 2 | No deprecation protocol for public API symbols | **ADR-022 activated** (was `Proposed (Deferred)`; its own trigger "breaking changes incur high coordination costs" had fired). Defines the public API surface, a one-release-cycle deprecation contract, the `DeprecationWarning`-vs-fail-loud boundary, `0.x` versioning, a retroactive position on the 0.4.0 removals, and a release checklist as the enforcement point. | #28 |
 | C-19 | 3 | `scipy` is an undeclared runtime dependency | Declared `scipy = "^1.11"` in `pyproject.toml`. It was a load-time import satisfied only transitively via scikit-learn. | #29 |

--- a/tests/test_metric_frame.py
+++ b/tests/test_metric_frame.py
@@ -264,6 +264,46 @@ class TestToMetricFrameBeige:
         assert isinstance(mf.metadata.scoring_code_version, str)
         assert mf.metadata.scoring_code_version
 
+    def test_scoring_code_version_identifies_the_code_that_ran(self, monkeypatch):
+        """C-25: a bare version cannot distinguish the tree from the last install.
+
+        `importlib.metadata` reports the *installed distribution*, not the executing
+        code. Under an editable install they drift as soon as the source moves ahead of
+        the last `pip install` — measured on 2026-08-02 with the tree at 1.0.0 and the
+        dist-info at 0.5.0, emitting frames stamped `0.5.0` from 1.0.0 code.
+
+        The previous version of this test asserted only that the stamp was a non-empty
+        string, so it was satisfied by exactly the wrong answer.
+        """
+        import subprocess
+        from pathlib import Path
+        from views_evaluation.evaluation import metric_frame as mf_mod
+
+        head = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True, text=True, cwd=Path(__file__).parent,
+        ).stdout.strip()
+        if not head:
+            pytest.skip("not running from a git worktree")
+
+        stamp = mf_mod.default_scoring_code_version()
+        assert stamp and stamp.endswith(f"+g{head}"), (
+            f"stamp {stamp!r} does not identify the running code (HEAD {head}). A bare "
+            f"version here is the C-25 defect: it is indistinguishable from a stale one."
+        )
+
+    def test_scoring_code_version_is_bare_when_there_is_no_worktree(self, monkeypatch):
+        """A wheel install has no `.git` and correctly stamps a bare version.
+
+        That is a property of how the package was installed, not a failure — ADR-015's
+        fault-versus-data-property test — so it must not raise and must not invent a SHA.
+        """
+        from views_evaluation.evaluation import metric_frame as mf_mod
+
+        monkeypatch.setattr(mf_mod, "_source_git_sha", lambda: None)
+        stamp = mf_mod.default_scoring_code_version()
+        assert stamp and "+g" not in stamp, f"expected a bare version, got {stamp!r}"
+
     def test_partition_level_default_to_empty_string(self):
         report = EvaluationReport('t', 'regression', 'point', _regression_point_results())
         mf = report.to_metric_frame()  # no partition/level

--- a/views_evaluation/evaluation/metric_frame.py
+++ b/views_evaluation/evaluation/metric_frame.py
@@ -75,18 +75,68 @@ def _json_default(obj: Any) -> Any:
     raise TypeError(err_msg)
 
 
-def default_scoring_code_version() -> Optional[str]:
-    """The installed views-evaluation package version (NOT a git SHA — unavailable in a wheel).
+def _source_git_sha() -> Optional[str]:
+    """Short SHA of the worktree this module is running from, or None.
 
-    Returns None if the package metadata cannot be resolved (e.g. running from an
-    uninstalled source tree).
+    Read from `.git` directly rather than shelling out: `git` is not guaranteed to exist
+    where evaluations run, and a missing binary must not change what gets stamped.
+    """
+    path = Path(__file__).resolve().parent
+    for candidate in (path, *path.parents):
+        git = candidate / ".git"
+        if not git.exists():
+            continue
+        try:
+            if git.is_file():  # worktree: `.git` is a file pointing at the real dir
+                git = Path(git.read_text().split("gitdir:", 1)[1].strip())
+            head = (git / "HEAD").read_text().strip()
+            if head.startswith("ref:"):
+                ref = head.split(":", 1)[1].strip()
+                target = git / ref
+                if target.exists():
+                    return target.read_text().strip()[:7]
+                packed = git / "packed-refs"
+                if packed.exists():
+                    for line in packed.read_text().splitlines():
+                        if line.endswith(f" {ref}"):
+                            return line.split()[0][:7]
+                return None
+            return head[:7]
+        except (OSError, IndexError):
+            return None
+    return None
+
+
+def default_scoring_code_version() -> Optional[str]:
+    """The version stamped into an emitted MetricFrame's provenance.
+
+    The installed distribution's version, plus `+g<sha>` when this module is running
+    from a git worktree.
+
+    **Why the SHA.** The version alone comes from `importlib.metadata`, which reports the
+    *installed distribution*, not the code being executed. Under an editable install —
+    which is how the platform runs this package — those drift the moment the source tree
+    moves ahead of the last `pip install`. Register **C-25** records a measured instance:
+    with the tree at 1.0.0 and the dist-info still at 0.5.0, emitted frames were stamped
+    `0.5.0` by 1.0.0 code, silently, in the artifact whose entire purpose is to be the
+    record. A bare version number cannot distinguish the two states; a version plus a SHA
+    can.
+
+    A wheel install has no worktree and correctly stamps a bare version — that is a
+    property of how the package was installed, not a failure, so no SHA is not an error
+    (ADR-015's fault-versus-data-property test).
+
+    Returns None if the distribution metadata cannot be resolved at all, e.g. running
+    from an uninstalled source tree.
     """
     from importlib.metadata import PackageNotFoundError, version
 
     try:
-        return version("views_evaluation")
+        installed = version("views_evaluation")
     except PackageNotFoundError:
         return None
+    sha = _source_git_sha()
+    return f"{installed}+g{sha}" if sha else installed
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes the two remaining items from the falsification audits.

## C-25 — `scoring_code_version` could not identify the running code

`importlib.metadata` reports the **installed distribution**, not the executing code. Under an editable install — how the platform runs this package — the two drift the moment the source moves ahead of the last `pip install`.

Measured: with the tree at 1.0.0 and the dist-info still at 0.5.0, emitted frames were stamped `0.5.0` **by 1.0.0 code**, silently, in the artifact whose entire purpose is to be the record.

`default_scoring_code_version()` now appends `+g<sha>` when running from a git worktree (`1.0.0+g5469690`). A wheel install has no worktree and stamps a bare version exactly as before — a property of how the package was installed, not a failure, so no SHA is not an error (ADR-015's fault-versus-data-property test).

**Nothing changes for anyone installing from PyPI**, which is why this needs no release to take effect where it matters: the affected population is dev checkouts, and those run from source.

`.git` is read directly rather than shelling out — `git` is not guaranteed to exist where evaluations run, and a missing binary must not change what gets stamped. Handles worktree `.git` files and packed-refs.

C-25's original proposal is recorded as **falsified**: "cut the 0.5.0 release so the label is meaningful" does not help, because the drift is between the install and the source, not between versions.

### The test was satisfied by the wrong answer

```python
assert isinstance(mf.metadata.scoring_code_version, str)
assert mf.metadata.scoring_code_version          # non-empty — that is all it checked
```

It now asserts the stamp identifies `HEAD`, plus a second test pinning the wheel case so a SHA is never invented. Verified by re-injecting the bare-version defect and watching it fail, then pass when restored.

## pytest `^8.3.3` → `^9.0.3`

Clears a Dependabot advisory (`pytest < 9.0.3`, tmpdir handling). Dev-only, never shipped. **Verified before bumping:** full suite passes on pytest 9.1.1.

| Gate | Result |
|---|---|
| `pytest` | 365 passed |
| `ruff` / `validate_docs.sh` | clean / passed |
| register | C-25 closed; header 12 = 12 entries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)